### PR TITLE
[1주차] 재귀 / python - 최한준

### DIFF
--- a/최한준/1주차[재귀]/10870.py
+++ b/최한준/1주차[재귀]/10870.py
@@ -1,0 +1,13 @@
+import sys
+
+N = int(sys.stdin.readline())
+
+arr = [0] * (N+1)
+
+def fib(i):
+    if i == 0 or i == 1:
+        return i
+    else:
+        return fib(i-2) + fib(i-1)
+
+print(fib(N))

--- a/최한준/1주차[재귀]/10872.py
+++ b/최한준/1주차[재귀]/10872.py
@@ -1,0 +1,13 @@
+import sys
+
+N = int(sys.stdin.readline())
+ans = 1
+
+def r(i):
+    if i == 1 or i == 0:
+        return 1
+    else:
+        return i * r(i - 1);
+
+
+print(r(N))

--- a/최한준/1주차[재귀]/11729.py
+++ b/최한준/1주차[재귀]/11729.py
@@ -1,0 +1,20 @@
+import sys
+
+N = int(sys.stdin.readline())
+
+cnt = 0
+
+
+def hanoi(n, st, mid, ed):
+    global cnt
+    cnt += 1
+    if n == 1:
+        print(f"{st} {ed}")
+    else:
+        hanoi(n - 1, st, ed, mid)
+        print(f"{st} {ed}")
+        hanoi(n - 1, mid, st, ed)
+
+
+print((1 << N) - 1)
+hanoi(N, 1, 2, 3)

--- a/최한준/1주차[재귀]/20164.py
+++ b/최한준/1주차[재귀]/20164.py
@@ -1,0 +1,37 @@
+import sys
+import math
+
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+N = None
+def set_variable():
+    global N 
+    N = get_input()
+
+
+def solution():
+    def rec(num):
+        cnt = 0
+        for i in num:
+            cnt += 1 if int(i) % 2 else 0
+        if len(num) == 1:
+            return cnt, cnt
+        elif len(num) == 2:
+            min_cnt, max_cnt  = rec(str(sum(map(int, num))))
+            return cnt +  min_cnt, cnt + max_cnt
+        else:
+            min_cnt = math.inf
+            max_cnt = 0
+            for i in range(1, len(num) - 1):
+                for j in range(i + 1, len(num)):
+                    now_min, now_max = rec(str(sum(map(int, [num[:i], num[i:j], num[j:]]))))
+                    min_cnt = min(min_cnt, now_min)
+                    max_cnt = max(max_cnt, now_max)
+            return cnt + min_cnt, cnt + max_cnt
+    
+    print(*rec(str(N)))
+
+if __name__ == "__main__":
+    set_variable()
+    solution()

--- a/최한준/1주차[재귀]/24060.py
+++ b/최한준/1주차[재귀]/24060.py
@@ -1,0 +1,59 @@
+import sys
+
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+N, K = None, None
+arr = None
+cnt = None
+
+def merge(A, l, mid, r):
+    global K, cnt
+    i, j = l, mid + 1 # python은 append로 구현하면 필요없음.
+    tmp = []
+    while i <= mid and j <= r:
+        if A[i] <= A[j]:
+            tmp.append(A[i])
+            i = i + 1
+        else:
+            tmp.append(A[j])
+            j = j + 1
+    
+    while i <= mid:
+        tmp.append(A[i])
+        i += 1
+    while j <= r:
+        tmp.append(A[j])
+        j = j + 1
+
+    i= l
+    while i <= r:
+        cnt += 1
+        A[i] = tmp[i-l]
+        if cnt == K:
+            print(A[i])
+            sys.exit(0)
+        i += 1
+
+def merge_sort(A, l, r):
+    if l < r:
+        mid = (l + r) // 2
+        merge_sort(A, l, mid)
+        merge_sort(A, mid + 1, r)
+        merge(A, l, mid, r) #  병합
+
+
+def set_variable():
+    global N, K, arr, cnt
+    cnt = 0
+    N, K = get_line()
+    arr = list(get_line())
+
+def solution():
+    global N, K, arr, cnt
+    merge_sort(arr, 0, len(arr)-1)
+    print(-1)
+
+if __name__ == "__main__":
+    set_variable()
+    solution()

--- a/최한준/1주차[재귀]/2447.py
+++ b/최한준/1주차[재귀]/2447.py
@@ -1,0 +1,17 @@
+import sys
+
+N = int(sys.stdin.readline())
+
+
+def star(n):
+    if n == 1:
+        return ['*']
+    n = n // 3
+    a = star(n)
+    top = [i * 3 for i in a]
+    middle = [i + ' ' * n + i for i in a]
+    return top + middle + top
+
+
+mystar = '\n'.join(star(N))
+print(mystar)

--- a/최한준/1주차[재귀]/25501.py
+++ b/최한준/1주차[재귀]/25501.py
@@ -1,0 +1,34 @@
+import sys
+
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+N = None
+cnt = None
+S = None
+def recursion(s, l, r):
+    global cnt
+    cnt += 1
+    if l >= r: return 1
+    elif s[l] != s[r]: return 0
+    else: return recursion(s, l+1, r-1)
+
+def isPalindrome(s):
+    global cnt 
+    cnt = 0
+    return recursion(s, 0, len(s)-1)
+
+
+def set_variable():
+    global N, cnt
+    N = get_input()
+
+def solution():
+    global N, cnt, S
+    for _ in range(N):
+        S = sys.stdin.readline().rstrip()
+        print(isPalindrome(S), cnt)
+
+if __name__ == "__main__":
+    set_variable()
+    solution()


### PR DESCRIPTION
# 1주 차 재귀
- [BOJ 10872 팩토리얼](https://www.acmicpc.net/problem/10872)
    - DP 기법과 재귀 문을 이용해 간단히 해결했습니다.
    - DP기법을 사용한 이유는 불필요한 재귀 호출을 방지하기 위함입니다.
- [BOJ 10870 피보나치 수 5](https://www.acmicpc.net/problem/10870)
    - DP 기법과 재귀 문을 이용해 간단히 해결했습니다.
    - DP 기법을 사용한 이유는 불필요한 재귀 호출을 방지하기 위함입니다.
- [BOJ 25501 재귀의 귀재](https://www.acmicpc.net/problem/25501)
    -  예시 코드를 파이썬으로 구현한 뒤, 재귀 호출하는 함수 앞쪽에 전역변수 `cnt`를 두어 재귀 호출 개수를 세어 문제를 해결했습니다.
- [BOJ 24060 알고리즘 수업 - 병합 정렬 1](https://www.acmicpc.net/problem/24060)
    -  합병 정렬의 Pseudo Code를 Python으로 구현한 뒤, 결과를 원본 배열 `A`에 저장할 때 저장 횟수를 세어 문제의 조건에 맞게 출력하는 방향으로 문제를 해결했습니다.
- [BOJ 2447 별 찍기 - 10](https://www.acmicpc.net/problem/2447)
    - Python의 List comprehension을 빠르게 각 재귀 Level에서의 배열을 생성한 뒤, 병합하는 과정으로 최적화했습니다.
    - 모든 원소가 공백인 배열을 생성한 뒤 내부에 `*`을 채우거나 반대로 모든 원소가 `*`인 배열을 생성한 뒤 내부에 공백문자를 채우는 방식으로 하면 조금 더 오래 걸리게 됩니다.
    - Python 기준 2000ms -> 48 ms
- [BOJ 11729번 하노이 탑 이동 순서](https://www.acmicpc.net/problem/11729)
    - 하노이탑의 이동 과정을 일반화하여 재귀 구조로 해결하였습니다.
        - 만약 K개의 탑을 `from`-> `to`로 `by` 위치를 이용해 움직이려 한다면 일반항은 다음과 같습니다.
            - 먼저 `K-1` 개의 블럭을 `by` 위치로 이동한 뒤
            - `K` 번째 블럭을 `to`로 이동합니다.
            - 마지막으로 `by` 위치의 `K-1` 개의 블럭을 다시 `to`로 옮겨주면 됩니다.
- [BOJ 20164번 홀수 홀릭 호석](https://www.acmicpc.net/problem/20164)
    - 주어진 문제 조건이 모든 과정 중에서 일어나고, 또한 세부 과정 또한 동일하게 일어나는 것에서 `재귀` 구조인 것을 파악했습니다.
    - 이후 주어진 조건에 맞게 일반항을 정의해 구현하면 어렵지 않게 해결할 수 있습니다. 다만 문제에서 최솟값, 최댓값을 모두 요구하므로 모든 재귀 Level에서 최솟값과 최댓값을 Return하면 됩니다.
    - 일반항은 다음과 같습니다.
        - 수의 각 자리 숫자 중에서 홀수의 개수를 종이에 적는다.
        - 수가 한 자리이면 더 이상 아무것도 하지 못하고 종료한다.
            - 이때의 최댓값과 최솟값은 모두 같습니다.
        - 수가 두 자리이면 2개로 나눠서 합을 구하여 새로운 수로 생각한다.
            - 이때의 최댓값과 최솟값은 모두 같습니다.
        - 수가 세 자리 이상이면 임의의 위치에서 끊어서 3개의 수로 분할하고, 3개를 더한 값을 새로운 수로 생각한다.
            - 임의의 위치에서 끊어서 새로운 수를 만들어 낼 때 다른 경우의 수가 생기므로, 여기서 최댓값과 최솟값을 갱신하는 과정이 필요합니다.

한 주간 고생하셨습니다!
