### PR TITLE
[1주차] 재귀(2) / python - 강수아

### DIFF
--- a/sua/week1/10870.py
+++ b/sua/week1/10870.py
@@ -8,3 +8,10 @@ def pibo(n):
     return l[n]
 
 print(pibo(int(sys.stdin.readline())))
+
+def recursivpibo(n):
+    if n <= 1:
+        return n
+    return recursivpibo(n-1) + recursivpibo(n-2)
+
+print(recursivpibo(int(sys.stdin.readline())))

--- a/sua/week1/10872.py
+++ b/sua/week1/10872.py
@@ -7,3 +7,11 @@ def fac(n):  # O(N)
     return res
 
 print(fac(int(sys.stdin.readline())))
+
+def recursivefac(n):
+    ret = 1
+    if n > 0:
+        ret = n * recursivefac(n-1)
+    return ret
+
+print(recursivefac(int(sys.stdin.readline())))

--- a/sua/week1/11729.py
+++ b/sua/week1/11729.py
@@ -1,0 +1,17 @@
+import sys
+n = int(sys.stdin.readline())
+
+# 마지막을 제외한 원판들을 모두 보조 장대에 놓는다.
+# 마지막 원판을 목표 장대에 놓는다.
+# 보조 장대에 있는 나머지 원판을 모두 목표 장대에 놓는다.
+
+def hanoi(n,start, target, temp):
+    if n == 1:
+        print(start, target)
+        return
+    hanoi(n-1, start, temp, target)
+    hanoi(1, start, target, temp)
+    hanoi(n-1, temp, target, start)
+
+print(2**n - 1)
+hanoi(n, 1, 3, 2)

--- a/sua/week1/20164.py
+++ b/sua/week1/20164.py
@@ -1,0 +1,32 @@
+import sys
+
+
+def cntodd(num: int):  # 자리수별 odd counting method
+    oddcnt = 0
+    while num:
+        if (num % 10) % 2 != 0:
+                oddcnt += 1
+        num //= 10
+    return oddcnt
+
+
+def seq(n: str, total: int):
+    if len(n) == 1:
+        res.append(total)
+        return
+
+    if len(n) == 2:
+        newnum = int(str(n)[0]) + int(str(n)[1])
+        seq(str(newnum), total + cntodd(newnum))
+
+    else:  # 임의의 위치에서 끊어 3개 수로 분할 -> 끊는 위치에 따라 최종값 분기 -> 분기별로 저장 & 비교 필요
+        for i in range(1, len(str(n))):  # 브루트포스 # 같은 위치 끊으면 x
+            for j in range(i + 1, len(str(n))):
+                newnum = int(str(n)[:i]) + int(str(n)[i:j]) + int(str(n)[j:])
+                seq(str(newnum), total + cntodd(newnum))
+
+
+n = sys.stdin.readline().rstrip() # 1 ≤ N ≤ 10^9 - 1
+res = []
+seq(n, cntodd(int(n)))
+print(min(res), max(res))

--- a/sua/week1/24060.py
+++ b/sua/week1/24060.py
@@ -1,7 +1,45 @@
 import sys
 n, k = map(int, sys.stdin.readline().split())
 l = list(map(int, sys.stdin.readline().split()))
+savedorder = []
+
 
 def merge_sort(arr):
-    if
-        
+    if len(arr) == 1:
+        return arr
+
+    mid = (len(arr) + 1) // 2
+
+    left = merge_sort(arr[:mid])
+    right = merge_sort(arr[mid:])
+
+    i = j = 0
+    l2 = []
+    while (len(left) > i) and (len(right) > j):
+        if left[i] < right[j]:
+          l2.append(left[i])
+          savedorder.append(left[i])
+          i += 1
+
+        else:
+            l2.append(right[j])
+            savedorder.append(right[j])
+            j += 1
+    while i < len(left):
+        l2.append(left[i])
+        savedorder.append(left[i])
+        i += 1
+    while j < len(right):
+        l2.append(right[j])
+        savedorder.append(right[j])
+        j += 1
+    return l2
+
+merge_sort(l)
+
+if len(savedorder) >= k:
+    print(savedorder[k-1])
+else:
+    print(-1)
+
+print(savedorder)

--- a/sua/week1/2447.py
+++ b/sua/week1/2447.py
@@ -1,0 +1,24 @@
+import sys
+
+# 패턴 반복 -> 재귀
+# 패턴: 가운데 n/3*n/3크기의 정사각형을 n/3의 패턴으로 감싸기
+# 별 하나하나를 기본 패턴으로 치환
+
+
+def printstar(n):
+    if n == 1:
+        return ['*']
+    stars = printstar(n // 3)
+    l = []
+
+    for s in stars:
+        l.append(s * 3)
+    for s in stars:
+        l.append(s + ' '*(n//3) + s)
+    for s in stars:
+        l.append(s * 3)
+    return l
+
+
+n = int(sys.stdin.readline())
+print('\n'.join(printstar(n)))


### PR DESCRIPTION
- BOJ 10872 팩토리얼
  - 재귀 사용 풀이 추가 `recursivefac()`
- BOJ 10870 피보나치수 5
  - 재귀 사용 풀이 추가 `recursivpibo()`
- BOJ 11729 하노이탑이동순서
  - 하단의 룰 구현하여 해결
    1. 마지막을 제외한 원판들을 모두 보조 장대에 놓는다.
    2. 마지막 원판을 목표 장대에 놓는다.
    3. 보조 장대에 있는 나머지 원판을 모두 목표 장대에 놓는다.
- BOJ 20164 홀수홀릭호석
  - 자리수별 odd counting method인 `cntodd()`, 연산 처리 method인 `seq()` 구현
  - 최소, 최댓값은 이중 for문 사용해 모든 경우의 수 처리
- BOJ 24060 병합정렬 1
  - 병합정렬 구현
- BOJ 2447 별찍기 10
  - 패턴 반복을 재귀로 처리
  - 기본 패턴: 가운데 n/3*n/3크기의 정사각형을 n/3의 패턴으로 감싸기
  - 별 하나하나를 기본 패턴으로 치환하여 풀이 