### PR TITLE
[2주차] 백트래킹 / python - 최한준

### DIFF
--- a/최한준/2주차[백트래킹]/14888.py
+++ b/최한준/2주차[백트래킹]/14888.py
@@ -1,0 +1,56 @@
+import sys
+import math
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+min_value = None
+max_value = None
+N = None
+arr = None
+op_cnt = None
+op_arr = None
+cnt = 0
+
+def set_variable():
+    global min_value, max_value, N, arr, op_cnt, op_arr
+    N = get_input()
+    arr = list(get_line())
+    op_arr = []
+    op_cnt = list(get_line())
+    min_value = math.inf
+    max_value = -math.inf # 알게된 것.
+
+def solution():
+    global min_value, max_value, N, arr, op_cnt, op_arr,cnt
+    def cal():
+        ret = arr[0]
+        for num, op in zip(arr[1:], op_arr):
+            if op   == 0 : ret += num
+            elif op == 1 : ret -= num
+            elif op == 2 : ret *= num
+            elif op == 3 : ret = int(ret / num)
+        return ret
+    
+    def rec(depth):
+        if depth == len(arr) - 1:
+            max_value = max(max_value, cal())
+            min_value = min(min_value, cal())
+            return
+        else:
+            for idx in range(4):
+                if op_cnt[idx] > 0:
+                    op_cnt[idx] -= 1
+                    op_arr.append(idx)
+                    rec(depth + 1)
+                    op_arr.pop()
+                    op_cnt[idx] += 1
+                    
+    
+    rec(0)
+    print(max_value)
+    print(min_value)
+
+
+if __name__ == "__main__":
+    set_variable()
+    solution()

--- a/최한준/2주차[백트래킹]/14889.py
+++ b/최한준/2주차[백트래킹]/14889.py
@@ -1,0 +1,45 @@
+import sys
+import math
+
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+N = None
+arr = None
+top = None
+bottom = None
+ans = None
+
+def set_variable():
+    global N, arr, top, bottom, ans
+    N = get_input()
+    arr = [list(get_line()) for _ in range(N)]
+    ans = math.inf
+
+def solution():
+    def rec(depth, team1, team2):
+        global N, arr, top, bottom, ans
+        if depth == N:
+            sum1, sum2 = 0, 0
+            for i in team1:
+                for j in team1:
+                    sum1 += arr[i][j]
+            for i in team2:
+                for j in team2:
+                    sum2 += arr[i][j]
+            ans = min(ans, abs(sum1- sum2))
+        else:
+            if len(team1) == N//2:
+                rec(depth + 1, team1 , team2 + [depth])
+            elif len(team2) == N // 2:
+                rec(depth + 1, team1 + [depth], team2)
+            else:
+                rec(depth + 1, team1 + [depth], team2)
+                rec(depth + 1, team1, team2 + [depth])
+    
+    rec(0, [], [])
+    print(ans)
+
+if __name__ == "__main__":
+    set_variable()
+    solution()

--- a/최한준/2주차[백트래킹]/14889_비재귀.py
+++ b/최한준/2주차[백트래킹]/14889_비재귀.py
@@ -1,0 +1,26 @@
+import sys
+import math
+import itertools 
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+N = None
+arr = None
+
+def set_variable():
+    global N, arr
+    N = get_input()
+    arr = [list(get_line()) for _ in range(N)]
+
+def solution():
+    global N, arr, ans
+    s=sum(p:=[sum(i)+sum(j)for i,j in zip(arr,zip(*arr))])//2
+    print(min(abs(s-sum(i))for i in itertools.combinations(p,int(N)//2)))
+    print(p, "-p")
+    print([i for i in itertools.combinations(p,int(N)//2)])
+    for i,j in zip(arr,zip(*arr)):
+        print(i, j)
+
+if __name__ == "__main__":
+    set_variable()
+    solution()

--- a/최한준/2주차[백트래킹]/15649.py
+++ b/최한준/2주차[백트래킹]/15649.py
@@ -1,0 +1,35 @@
+import sys
+
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+    
+N, M = None, None
+visited = None
+arr = None
+    
+def set_variable():
+    global N, M, visited, arr
+    N, M = get_line()
+    visited = [False for _ in range(N + 1)]
+    arr = [0 for _ in range(M)]
+
+def solution():
+    global N, M, visited, arr
+    def rec(depth):
+        if depth == M:
+            for i in range(M):
+                print(arr[i], end=" ")
+            print("")
+        else:
+            for i in range(1, N + 1):
+                if visited[i] == False:
+                    visited[i] = True
+                    arr[depth] = i
+                    rec(depth + 1)
+                    visited[i] = False
+     
+    rec(0)
+    
+if __name__ == "__main__":
+    set_variable()
+    solution()

--- a/최한준/2주차[백트래킹]/15650.py
+++ b/최한준/2주차[백트래킹]/15650.py
@@ -1,0 +1,36 @@
+import sys
+from collections import deque
+
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+N, M = None, None
+
+def set_variable():
+    global N, M
+    N, M = get_line()
+
+def solution():
+    global N, M
+    visited = [False for _ in range(N)] 
+    deq = deque()
+    def recursive(level, now_list, last_num):
+        if level == M:
+            print(*now_list)
+            return
+        else:
+            for idx, i in enumerate(range(last_num, N)):
+                idx += last_num
+                if visited[i] == False:
+                    visited[idx] = True
+                    now_list.append(idx+1)
+                    recursive(level + 1, now_list, idx + 1)
+                    now_list.pop()
+                    visited[idx] = False
+
+    recursive(0, deq, 0)
+
+
+if __name__ == "__main__":
+    set_variable()
+    solution()

--- a/최한준/2주차[백트래킹]/15686.py
+++ b/최한준/2주차[백트래킹]/15686.py
@@ -1,0 +1,40 @@
+import sys
+import math
+from itertools import *
+
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+N, M = None, None
+arr = None
+c_list = None
+h_list = None
+
+def set_variable():
+    global N, M, c_list, h_list
+    N, M = get_line()
+    arr = [list(get_line()) for _ in range(N)]
+    c_list = []
+    h_list = []
+    for i in range(N):
+        for j in range(N):
+            if arr[i][j] == 1 : h_list.append((i, j))
+            if arr[i][j] == 2 : c_list.append((i, j))
+
+def solution():
+    def cal(c_comb):
+        global N, M, c_list, h_list
+        ret = 0
+        for h_y, h_x in h_list:
+            min_value = math.inf
+            for y, x in c_comb:
+                min_value = min(min_value, abs(y - h_y) + abs(x - h_x))
+            ret += min_value
+        return ret
+
+    print(min([cal(c_comb)for c_comb in combinations(c_list, M)]))
+
+
+if __name__ == "__main__":
+    set_variable()
+    solution()

--- a/최한준/2주차[백트래킹]/2580.py
+++ b/최한준/2주차[백트래킹]/2580.py
@@ -1,0 +1,55 @@
+import sys
+from pprint import pprint
+# import numpy as np
+
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+arr = None
+empty_arr = None
+col = None
+row = None
+grd = None
+cnt = None
+
+def set_variable():
+    global arr, empty_arr, col, row, grd, cnt
+    cnt = 0
+    empty_arr = []
+    arr = [list(get_line()) for _ in range(9)]
+    col = [[True for _ in range(10)] for _ in range(9)] # col[i][j] = i열의 j 숫자가 들어올 수 있나?
+    row = [[True for _ in range(10)] for _ in range(9)]
+    grd = [[True for _ in range(10)] for _ in range(9)]
+    for i in range(9):
+        for j in range(9):
+            if arr[i][j] == 0:
+                empty_arr.append((i, j))
+            else:                
+                col[j][arr[i][j]] = False
+                row[i][arr[i][j]] = False
+                grd[i//3 * 3 + j // 3][arr[i][j]] = False
+
+def solution():
+    def b_track(depth):
+        global arr, empty_arr, col, row, grd, cnt
+        if depth == len(empty_arr):
+            for line in arr:
+                print(*line)
+            sys.exit(0)
+        else:
+            now_y, now_x = empty_arr[depth]
+            for i in range(1, 10):
+                if col[now_x][i] == True and row[now_y][i] == True and grd[now_y // 3 * 3 + now_x // 3][i] == True:
+                    col[now_x][i] = row[now_y][i] = grd[now_y // 3 * 3 + now_x // 3][i] = False
+                    print()
+                    arr[now_y][now_x] = i
+                    b_track(depth + 1)
+                    arr[now_y][now_x] = 0
+                    col[now_x][i] = row[now_y][i] = grd[now_y // 3 * 3 + now_x // 3][i] = True
+    
+    b_track(0)
+
+
+if __name__ == "__main__":
+    set_variable()
+    solution()


### PR DESCRIPTION
- [BOJ 15649 N과 M (1)](https://www.acmicpc.net/problem/15649)
- [BOJ 15649 N과 M (2)](https://www.acmicpc.net/problem/15650)
    - 백트래킹을 활용해 간단히 해결했습니다.
- [BOJ 9663 N-Queen](https://www.acmicpc.net/problem/9663)
    - 백트래킹 알고리즘을 이용해 퀸이 놓을 수 없는 자리를 Pruning함으로써 최적화를 진행했습니다.
    - 단순 Pruning만으로는 Python으로 제출했을 때 시간초과를 맞이하게 됩니다.
    - 그래서 JIT 컴파일 방식의 PyPy3로 제출언어를 변경했을 시에는 정상적으로 통과할 수 있습니다.
        -  JIT 컴파일 방식은 실행 시점에서 인터프리트 방식으로 기계어 코드를 생성하면서 그 코드를 캐싱하여, 같은 함수가 여러 번 불릴 때 매번 기계어 코드를 생성하는 것을 방지한다. 보통 재귀문 함수를 이용해 문제를 해결할 때 PyPy3를 사용하면 빨라지는 것을 관찰하기 쉽습니다.
        - 하지만 치명적인 단점은 PyPy3는 함수 호출시에 정적으로 큰 메모리를 할당하기 때문에 재귀가 깊게 들어가면 메모리 초과를 맞이하게 됩니다.
- [BOJ 2580 스도쿠](https://www.acmicpc.net/problem/2580)
    - 일반적으로 스도쿠를 푸는 방식과 백트래킹 방식이 굉장히 유사해 이를 그대로 구현하면 됩니다.
    - BOJ 19998 스도쿠 (Hard)는 Knuth x 알고리즘을 활용하는데, 이후에 같이 풀어보면 좋을 것 같습니다.
- [BOJ 14888 연산자 끼워넣기](https://www.acmicpc.net/problem/14888)
    - 이 문제는 N - 1개의 연산자들은 주어진 연산들의 갯수에 맞게 사용해 순서를 구성해서 계산하면 됩니다. 
    - 이 문제에서 실수 했던 건 음수 나눗셈 연산에서 반올림이 잘못될 수 도 있다는 것.
    - 예를 들어
        ```
        a = -5
        b = 3
        print(a//b) -> -2
        print(int(a/b)) -> -1
        실제 정답은 -1입니다.
        ``` 
    - 위의 예시처럼 음수 몫 연산을 할 때에는 `int(a/b)` 이용해야할 것 같습니다.
    - 그 이유는 `//` 연산자는 몫보다 작거나 같은 정수를 선택하게 되고, `/`는 소수 부분을 버리기 때문입니다.
- [BOJ 14889번 스타트와 링크](https://www.acmicpc.net/problem/14889)
    - Combination으로 nCn/2 갯수만큼 팀을 정해 각각 점수를 계산해 abs(스타트 팀 - 링크 팀)의 최소값을 구하면 됩니다.
- [BOJ 15686 치킨 배달](https://www.acmicpc.net/problem/15686)
    - 치킨집을 Combination을 적용해 조합을 만든 뒤 해당 치킨 집과 전체 집과의 L1 Norm(Manhattan distance)을 구하면 됩니다. 
    - 전처리로 각 치킨집과 각자 집의 거리를 미리 구해놓고 풀면 더 최적화 시킬 수 있습니다.
