### PR TITLE
[3주차] 동적계획법 / python - 최한준

### DIFF
--- a/최한준/3주차[동적계획법]/11054.py
+++ b/최한준/3주차[동적계획법]/11054.py
@@ -1,0 +1,38 @@
+import sys
+
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+N = None
+arr = None
+up_cnt = None
+down_cnt = None
+
+def set_variable():
+    global N, arr, up_cnt, down_cnt
+    N = get_input()
+    arr = list(get_line())
+    up_cnt = [0] * N
+    down_cnt = [0] * N
+
+
+def solution():
+    global N, arr, up_cnt, down_cnt
+    for i in range(N):
+        up_cnt[i] = 1
+        down_cnt[N-1-i] = 1
+        for j in range(i):
+            if arr[i] > arr[j]:
+                up_cnt[i] = max(up_cnt[i], up_cnt[j] + 1)
+            if arr[N - 1 - i] > arr[N - 1 - j]:
+                down_cnt[N - 1 - i] = max(down_cnt[N - 1 - i] , down_cnt[N - 1 - j] + 1)
+    
+    answer = 0
+    for i in range(N):
+        answer = max(answer, up_cnt[i] + down_cnt[i])
+    
+    print(answer - 1)
+
+if __name__ == "__main__":
+    set_variable()
+    solution()

--- a/최한준/3주차[동적계획법]/1149.py
+++ b/최한준/3주차[동적계획법]/1149.py
@@ -1,0 +1,32 @@
+import sys
+from copy import deepcopy
+
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+arr = None
+N = None
+dp = None
+
+def set_variable():
+    global arr, N, dp
+    N = get_input()
+    arr = [list(get_line()) for i in range(N)]
+    dp = [[0] * 3 for i in range(N)]
+    
+
+def solution():
+    global arr, N, dp
+    dp[0] = deepcopy(arr[0])
+    for i in range(1, N):
+        dp[i][0] = min(dp[i-1][1], dp[i-1][2]) + arr[i][0]
+        dp[i][1] = min(dp[i-1][0], dp[i-1][2]) + arr[i][1]
+        dp[i][2] = min(dp[i-1][0], dp[i-1][1]) + arr[i][2]
+    
+    print(min(dp[N-1]))
+        
+
+
+if __name__ == "__main__":
+    set_variable()
+    solution()

--- a/최한준/3주차[동적계획법]/12865.py
+++ b/최한준/3주차[동적계획법]/12865.py
@@ -1,0 +1,32 @@
+import sys
+
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+N, K = None, None
+bag = None
+max_value = None
+
+def set_variable():
+    global N, K, bag, max_value
+    N, K = get_line()
+    bag = list()
+    max_value = [0 for _ in range(K+1)]
+    for _ in range(N):
+        w, v = get_line()
+        bag.append((w, v))
+
+def solution():
+    global N,K, bag, max_value
+    for w, v in bag:
+        for j in range(K, 0, -1):
+            if w <= j:
+                max_value[j] = max(max_value[j], max_value[j - w] + v)
+           
+         
+    print(max(max_value))
+            
+
+if __name__ == "__main__":
+    set_variable()
+    solution()

--- a/최한준/3주차[동적계획법]/1463.py
+++ b/최한준/3주차[동적계획법]/1463.py
@@ -1,0 +1,18 @@
+import sys
+
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline())
+
+N = get_input()
+
+arr = [987654321] * (N + 1)
+arr1 = [0] * (N + 1)
+arr[1] = 0
+for i in range(1, N):
+    arr[i + 1] = min(arr[i] + 1, arr[i + 1])
+    if i * 3 <= N:
+        arr[i * 3] = min(arr[i * 3], arr[i] + 1)
+    if i * 2 <= N:
+        arr[i * 2] = min(arr[i * 2], arr[i] + 1)
+
+print(arr[N])

--- a/최한준/3주차[동적계획법]/1904.py
+++ b/최한준/3주차[동적계획법]/1904.py
@@ -1,0 +1,13 @@
+import sys
+
+MOD = 15746
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline())
+
+N = get_input()
+
+arr = [0, 1, 2] + [0] * (N + 1)
+
+for i in range(3, N + 1):
+    arr[i] = (arr[i - 1] + arr[i - 2]) % MOD
+print(arr[N])

--- a/최한준/3주차[동적계획법]/2565.py
+++ b/최한준/3주차[동적계획법]/2565.py
@@ -1,0 +1,34 @@
+import sys
+
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+
+arr = None
+N = None
+cnt = None
+
+def set_variable():
+    global arr, N, cnt
+    N = get_input()
+    arr = []
+    cnt = [0] * N
+    for _ in range(N):
+        idx, n = get_line()
+        arr.append((idx, n))
+    arr.sort()
+
+
+def solution():
+    global arr, N
+    for i in range(N):
+        cnt[i] = 1
+        for j in range(i):
+            if arr[i][1] > arr[j][1]:
+                cnt[i] = max(cnt[i], cnt[j] + 1)
+
+    print(N - max(cnt))
+
+if __name__ == "__main__":
+    set_variable()
+    solution()

--- a/최한준/3주차[동적계획법]/9251.py
+++ b/최한준/3주차[동적계획법]/9251.py
@@ -1,0 +1,31 @@
+import sys
+
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+s1 = None
+s2 = None
+cnt_arr = None
+
+def set_variable():
+    global s1, s2, cnt_arr
+    s1 = sys.stdin.readline().rstrip()
+    s2 = sys.stdin.readline().rstrip()
+    cnt_arr = [[0] * (len(s2) + 1) for _ in range(len(s1) + 1)]  
+
+def solution():
+    global s1, s2
+    for i in range(1, len(s1) + 1):
+        for j in range(1, len(s2) + 1):
+            if s1[i-1] == s2[j-1]:
+                cnt_arr[i][j] = cnt_arr[i-1][j-1] + 1
+            else:
+                cnt_arr[i][j] = max(cnt_arr[i][j-1], cnt_arr[i-1][j])
+    
+    print(cnt_arr[-1][-1])
+            
+
+
+if __name__ == "__main__":
+    set_variable()
+    solution()

--- a/최한준/3주차[동적계획법]/tempCodeRunnerFile.py
+++ b/최한준/3주차[동적계획법]/tempCodeRunnerFile.py
@@ -1,0 +1,1 @@
+max_value


### PR DESCRIPTION
- [BOJ 1904 01타일](https://www.acmicpc.net/problem/1904)
    - Fibonacci 일반항 구하는 것과 같은 문제임을 캐치하면 됩니다.
- [BOJ 1149 RGB거리](https://www.acmicpc.net/problem/1149)
    - `dp[i][color] = max(dp[i-1][another color])`를 계속 업데이트하면 됩니다.
- [BOJ 1463 1로 만들기](https://www.acmicpc.net/problem/1463)
    - `arr[i + 1] = min(arr[i] + 1, arr[i + 1])`
    - `arr[i * 3] = min(arr[i * 3], arr[i] + 1)`
    - `arr[i * 2] = min(arr[i * 2], arr[i] + 1)`
    - 위 3조건과 문제의 조건을 유지하며 DP Table을 갱신하면 됩니다.
- [BOJ 11054 가장 긴 바이토닉 부분 수열](https://www.acmicpc.net/problem/11054)
    - 1 -> N index가 증가할 때 증가하는 부분 수열의 길이
    - N -> 1 index가 감소할 때 증가하는 부분 수열의 길이
    - 같은 index에서 위 부분 수열의 길이의 합 - 1(중복된 본인의 index)를 하면 쉽게 답이 나옵니다.
- [BOJ 2565 전깃줄](https://www.acmicpc.net/problem/2565)
    - 이 문제는 이 문제가 LCS와 같은 형태인 라는 것을 깨닫는게 어려운 문제입니다.
    - 이렇게 생각하면 LCS임을 알기가 쉬울 수 있습니다.
        - 전기줄이 겹친다 -> (L_1, R_1), (L_2, R_2)가 있을 때 L_1 < L_2이면서 R_1 > R_2여야 합니다.
        - 따라서 L_1 < L_2 이면서 R_1 < R_2라면 겹치지 않으므로 이러한 상태를 유지하는 최대 전깃줄을 R_1 < R_2가 가장 많이 발생하는 LCS를 구하는 것과 같은 문제가 됩니다. 
- [BOJ 9251번 CLS](https://www.acmicpc.net/problem/9251)
    - LCS가 갱신되는 일반항을 구하면 쉽습니다.
    - 현재 고려중인 s1[i], s2[j]를 이용해 일반항을 구하면 다음과 같습니다.
        ```
        if s1_[i] == s_2[j]
            dp[i][j] = dp[i-1][j-1] + 1
        else
            dp[i][j] = max(dp[i-1][j], dp[i][j-1])
        ```
- [BOJ 12865 평범한 배낭](https://www.acmicpc.net/problem/12865)
    - Knapsack Algorithm의 기본 문제입니다.
    - 돈을 올려가며 모든 물건을 비교하면 됩니다.
    - 의사 다항 시간을 가지는 문제 기본적으로는 N-P Hard입니다.
