### PR TITLE
[6주차] 동적 계획법 2 / python - 최한준

### DIFF
--- a/최한준/6주차[동적계획법2]/110499.py
+++ b/최한준/6주차[동적계획법2]/110499.py
@@ -1,0 +1,38 @@
+import sys
+import math
+sys.setrecursionlimit(10**5 + 1)
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+arr = None
+N = None
+dp_table = None
+def set_variable():
+    global arr, N, dp_table
+    N = get_input()
+    arr = []
+    for _ in range(N):
+        arr.append(list(get_line()))
+    dp_table = [[math.inf for _ in range(N + 1)] for _ in range(N + 1)]
+        
+def solution():
+    def dp(s, e):
+        global arr, N, dp_table
+        if s == e:
+            return 0
+        if dp_table[s][e] != math.inf:
+            return dp_table[s][e]
+        else:
+            ret = math.inf
+            for i in range(s, e):
+                left = dp(s, i)
+                right = dp(i + 1, e)
+                ret = min(ret, left + right + arr[s][0] * arr[i][1] * arr[e][1])
+            dp_table[s][e] = ret
+            return dp_table[s][e]
+
+    print(dp(0, N - 1))
+
+if __name__ == "__main__":
+    set_variable()
+    solution() 

--- a/최한준/6주차[동적계획법2]/11066.py
+++ b/최한준/6주차[동적계획법2]/11066.py
@@ -1,0 +1,44 @@
+import sys
+import math
+sys.setrecursionlimit(10**9 + 1)
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+dp_table = None
+arr = None
+pre_fix = None
+K = None
+def set_variable():
+    global K, arr, dp_table, pre_fix
+    K = get_input()
+    arr = [0] + list(get_line())
+    pre_fix = [0] + [0 for _ in range(K)]
+    for i in range(1, K + 1):
+        pre_fix[i] = pre_fix[i-1] + arr[i]
+    dp_table = [[math.inf for _ in range(K + 1)] for _ in range(K + 1)]
+    
+
+def solution():
+    def dp(s, e):
+        global K, arr, dp_table, pre_fix
+        if s == e:
+            dp_table[s][e] = 0
+            return dp_table[s][e]
+        if dp_table[s][e] != math.inf:
+            return dp_table[s][e]
+        else:
+            ret = math.inf
+            for i in range(s, e):
+                left = dp(s, i)
+                right = dp(i + 1, e)
+                ret = min(ret, left + right)
+            dp_table[s][e] = ret + pre_fix[e] - pre_fix[s - 1]        
+            return dp_table[s][e]
+    
+    print(dp(1, K))
+
+if __name__ == "__main__":
+    TC = get_input()
+    for _ in range(TC):
+        set_variable()
+        solution()

--- a/최한준/6주차[동적계획법2]/1520.py
+++ b/최한준/6주차[동적계획법2]/1520.py
@@ -1,0 +1,41 @@
+import sys
+from collections import deque
+sys.setrecursionlimit(10**9)
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+N, M = None, None
+arr = None
+dp_table = None
+dx = [1, 0, -1, 0]
+dy = [0, 1, 0, -1]
+def set_variable():
+    global N, M, arr, dp_table
+    N, M = get_line()
+    arr = [list(get_line()) for _ in range(N)]
+    dp_table = [[-1] * M for _ in range(N)]
+
+def solution():
+    global N, M, arr, dp_table
+    def DFS(y, x):
+        def possible(y, x):
+            if 0 <= y < N and 0 <= x < M: return True
+            else: return False
+        if dp_table[y][x] != -1: 
+            return dp_table[y][x]
+        if y == 0 and x == 0:
+            return 1
+        else:
+            dp_table[y][x] = 0
+            for i in range(4):
+                nxt_y, nxt_x = y + dy[i], x + dx[i]
+                if possible(nxt_y, nxt_x) and arr[y][x] < arr[nxt_y][nxt_x]:
+                    dp_table[y][x] += DFS(nxt_y, nxt_x)
+            
+            return dp_table[y][x]
+    
+    print(DFS(N-1, M-1))
+
+if __name__ == "__main__":
+    set_variable()
+    solution()

--- a/최한준/6주차[동적계획법2]/20181.py
+++ b/최한준/6주차[동적계획법2]/20181.py
@@ -1,0 +1,41 @@
+import sys
+
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+N, K = None, None
+arr = None
+dp_table = None
+prefix = None
+
+def set_variable():
+    global N, K, arr, dp_table, prefix
+    N, K = get_line()
+    arr = list(get_line())
+    dp_table = [0] * (N + 1)
+    prefix = [0]
+    
+
+def solution():
+    global N, K, arr, dp_table, prefix
+    l = r = lmax = answer = s = 0
+    while True:
+        if s >= K:
+            lmax = 0 if l == 0 else max(lmax, dp_table[l - 1])
+            dp_table[r-1] = max(dp_table[r-1], lmax + s- K)
+            s -= arr[l]
+            l += 1
+        elif r == N:
+            break
+        else:
+            s += arr[r]
+            r+=1
+    for i in range(N):
+        answer = max(answer, dp_table[i])
+    print(answer)
+        
+        
+
+if __name__ == "__main__":
+    set_variable()
+    solution()

--- a/최한준/6주차[동적계획법2]/2293.py
+++ b/최한준/6주차[동적계획법2]/2293.py
@@ -1,0 +1,21 @@
+import sys
+input = sys.stdin.readline
+
+N, K = map(int, input().split(' '))
+coins = []
+for _ in range(N):
+    coins.append(int(input()))
+
+
+def solution():
+    dp = [0] * (K+1)
+    dp[0] = 1
+    for i in range(N):
+        coin = coins[i]
+        for j in range(coin, K+1):
+            dp[j] += dp[j-coin]
+
+    return dp[K]
+
+
+print(solution()) 

--- a/최한준/6주차[동적계획법2]/2629.py
+++ b/최한준/6주차[동적계획법2]/2629.py
@@ -1,0 +1,44 @@
+import sys
+sys.setrecursionlimit(10**9 + 1)
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+N, M = None, None
+chu = None
+weights = None
+dp_table = None
+
+def set_variable():
+    global N, M, chu, weights, dp_table
+    N = get_input()
+    chu = list(get_line()) + [0]
+    M = get_input()
+    weights = get_line()
+    dp_table = [[False] * (15000 + 1) for _ in range(N + 3)]
+
+def solution():
+    def dp(n, weight):
+        global N, M, chu, weights, dp_table
+        if n > N:
+            return 
+        if dp_table[n][weight] == True:
+            return
+
+        dp_table[n][weight] = True
+        dp(n + 1, weight) # 안 올린 경우
+        if n != N:
+            dp(n + 1, weight + chu[n]) # 오른쪽
+            dp(n + 1, abs(weight - chu[n]))  # 왼쪽
+
+    dp(0, 0)
+    for i in weights:
+        if i > 15000:
+            print("N", end= " ") 
+        elif dp_table[N][i]:
+            print("Y", end=" ")
+        else:
+            print("N", end= " ") 
+
+if __name__ == "__main__":
+    set_variable()
+    solution()

--- a/최한준/6주차[동적계획법2]/7579.py
+++ b/최한준/6주차[동적계획법2]/7579.py
@@ -1,0 +1,37 @@
+import sys
+import math
+
+get_line: iter = lambda: map(int, sys.stdin.readline().rstrip().split())
+get_input: int = lambda: int(sys.stdin.readline().strip())
+
+N, M = None, None
+memory = None
+cost = None
+dp_table = None
+
+def set_variable():
+    global N, M, memory, cost, dp_table
+    N, M = get_line()
+    memory = list(get_line())
+    cost = list(get_line())
+    dp_table = [0] * (10000 + 1)
+
+def solution():
+    sum_cost = sum(cost)
+    def kanpsack():
+        global N, M, memory, cost, dp_table
+        for i in range(N):
+            for j in range(sum_cost, cost[i] - 1, -1):
+                dp_table[j] = max(dp_table[j], dp_table[j-cost[i]] + memory[i])
+        
+    kanpsack()    
+    answer = math.inf
+    for i in range(sum_cost + 1):
+        if dp_table[i] >= M:
+            answer = min(answer, i)
+    print(answer)
+
+
+if __name__ == "__main__":
+    set_variable()
+    solution()

--- a/최한준/6주차[동적계획법2]/tempCodeRunnerFile.py
+++ b/최한준/6주차[동적계획법2]/tempCodeRunnerFile.py
@@ -1,0 +1,2 @@
+ visited[weight] = True
+        dp_table[n][weight] = True


### PR DESCRIPTION
- [BOJ 11066 파일 합치기](https://www.acmicpc.net/problem/11066)
    - Top-Down DP 방식으로 구현하는 것을 연습했습니다.
    - 개구간 dp[S, E] = max(dp[S][i] + dp[i + 1][E]) (S<= i < E) 를 계산하도록 하면 됨
    - 이때 시간복잡도를 이유로 prefix sum(누적합)을 이용해 해당 구간의 구간합을 구할 때 O(1)로 구할 수 있도록 최적화해야 함
- [BOJ 11049 행렬 곱셈 순서](https://www.acmicpc.net/problem/11049)
    - 행렬 A x B * B x C를 곱할 때 필요한 곱셈의 연산수가 A * B * C임을 관찰해야 합니다.
    - Top-Down DP 방식으로 구현했습니다.
    - arr[i][0,1]을 i번째 행렬의 행과 열이라고 할 때, 개구간 dp[S, E] = max(dp[S][i] + dp[i + 1][E] + arr[S][0] * arrr[I][1] * arr[E][1])를 이용해 DP Table을 계산하면 됩니다.
    - dp_table[s][e] = [s, e] 까지의 행렬의 연산의 최소값.
- [BOJ 1520 내리막 길](https://www.acmicpc.net/problem/1520)
    - Top-Down DP 방식으로 구현했습니다.
    - dp[y][x] = sum(dp[pre_y][pre_x])임을 관찰합니다.
    - 현재 위치는 현재 위치로 방문 가능한 위치에 방문 가능한 경우의 수를 합으로 갱신 가능합니다.
    - dp_table[y][x] = 시작지점에서 (y, x)로 오는 경로의 수
- [BOJ 2629 양팔저울](https://www.acmicpc.net/problem/2629)
    -  Top-Down DP 방식으로 구현했습니다.
    - 각각의 무게추의 조합에는 3가지 선택지가 있습니다. 
        1. 현재 고려중인 무게추를 건너뛴다
        2. 현재 고려중인 무게추를 왼쪽에 놓는다
        3. 현재 고려중인 무게추를 오른쪽에 놓는다.
    - 위 3가지를 방식을 이용해 각각의 무게가 가능한지 Top-Down DP를 진행합니다.
- [BOJ 2294 동전 1](https://www.acmicpc.net/problem/2294)
    - Bottom-Up DP 방식으로 구현했습니다.
    - 문제 조건 중에 사용한 동전의 구성이 같은데, 순서만 다른 것은 같은 경우이므로, 단순히 dp_table을 갱신하면 됩니다.
- [BOJ 7579 앱](https://www.acmicpc.net/problem/7579) 
    - Bottom-UP DP 방식으로 구현했습니다
    - 동전 1과 유사한 방식으로 해결했지만, Knapsack의 느낌이 있다 보면 될 듯 합니다.
- [BOJ 20181 꿈틀꿈틀 호석 애벌레 - 효율성](https://www.acmicpc.net/problem/20181) 
    - Bottom-UP DP 방식으로 구현했습니다.
    - 투 포인터를 이용해 애벌래가 현재 먹을 구간을 정하고, 해당 구간의 먹이의 합이 K를 넘는다면 L++을 아니라면 R++을 진행합니다.
    - 이때 dp_table[R] = R까지의 최대 먹이라고 정의를 한다면, 이를 dp_table[R] = dp_table[L-1] + prefix_sum[R] - prefix_sum[L - 1]로 갱신할 수 있습니다.