### PR TITLE
[8주차] 투 포인터 / java - 양진기

### DIFF
--- a/양진기/week8[투 포인터]/1450.java
+++ b/양진기/week8[투 포인터]/1450.java
@@ -1,0 +1,97 @@
+import java.io.*;
+import java.util.*;
+
+class Main{
+    /*
+        물건을 넣거나 넣지 않는다. -> 2가지
+        물건이 최대 30개이므로 2^30 -> 시간 초과
+
+        반으로 잘라 2^15 + 2^15로 계산한다.
+        weight1에 왼쪽 반, weight2에 오른쪽 반을 입력받는다.
+
+        weight1에서 각 물건을 넣고 넣지 않는 경우의 수 리스트를 sum1에 담는다.
+        weight2에서 각 물건을 넣고 넣지 않는 경우의 수 리스트를 sum2에 담는다.
+
+        결국엔 sum1 + sum2이 C가 되는 경우를 찾아야 한다.
+        여기서 sum1 리스트와 sum2 리스트를 모두 비교하자니 시간이 많이 걸린다.
+
+        다른 방향에서 생각하면 C - sum1 = sum2 이다.
+        sum2를 찾아보자. -> 이분 탐색으로 시간을 줄인다.
+        이분 탐색의 bound를 이용해서 sum2 값의 길이를 찾는다. -> 길이만큼 더해서 경우의 수를 누적한다.
+     */
+
+    static int n, c;
+
+    // sum2가 들어온다.
+    public static int binarySearch(ArrayList<Integer> sum , int target){
+        int left = 0, right = sum.size()-1, mid, answer = -1;
+
+        while(left <= right){
+            mid = (left + right) / 2;
+            if(sum.get(mid) <= target){ // 중간값이 target보다 작거나 같다면 -> 오른쪽에 있다.
+                answer = mid; // 작거나가 포함되어 있기 때문에 target이 되는 가장 마지막 인덱스를 담는다.
+                left = mid + 1;
+            } else {    // 중간값이 target보다 크다면 -> 왼쪽에 있다.
+                right = mid - 1;
+            }
+        }
+        return answer;
+    }
+
+    public static void dfs(int idx, int sum, ArrayList<Integer> weight, ArrayList<Integer> answer){
+
+        // 3. 탈출 조건
+        if(sum > c) return;
+        if(idx == weight.size()){
+            answer.add(sum);    // 마지막에 sum1/sum2에 담는다.
+            return;
+        }
+
+        // 1. 물건을 넣는 경우
+        dfs(idx + 1, sum + weight.get(idx), weight, answer); // weight의 인덱스번째를 sum에다 더해줌
+        // 2. 물건을 넣지 않는 경우
+        dfs(idx + 1, sum, weight, answer); // 물건을 넣지 않았으니 sum을 증가시키지 않음
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        c = Integer.parseInt(st.nextToken());
+
+        // 물건을 반으로 나누기
+        ArrayList<Integer> weight1 = new ArrayList<>();
+        ArrayList<Integer> weight2 = new ArrayList<>();
+
+        st = new StringTokenizer(br.readLine());
+        for(int i=0; i<n; i++){
+            // 반은 weight1에 넣기
+            if(i < n/2) weight1.add(Integer.parseInt(st.nextToken()));
+                // 나머지 반은 weight2에 넣기
+            else weight2.add(Integer.parseInt(st.nextToken()));
+        }
+
+        // 1. DFS로 sum1, sum2 만들기
+        ArrayList<Integer> sum1 = new ArrayList<>();
+        ArrayList<Integer> sum2 = new ArrayList<>();
+
+        dfs(0, 0, weight1, sum1); // 0번째 인덱스의 값을 weight1에서 가져와서 sum(0)을 sum1에 담는다.
+        dfs(0, 0, weight2, sum2); // 0번째 인덱스의 값을 weight2에서 가져와서 sum(0)을 sum2에 담는다.
+
+        // 2. sort 및 binary search
+        Collections.sort(sum2); // sum2만 정렬한다. -> 이분탐색해서 (c - sum1 = 0)의 값이 몇개(bound) 있는지 찾기 위해
+        int answer = 0;
+        for(int i=0; i < sum1.size(); i++){
+            int searchValue = c - sum1.get(i);  // c - sum1의 현재값을 하면 sum2에서 찾아야될 값을 구할 수 있다.
+            answer += binarySearch(sum2, searchValue) + 1;    // sum2에서 c - sum1이 값을 찾는다. 인덱스값을 반환하면 +1로 카운팅
+        }
+
+        bw.write(String.valueOf(answer));
+        bw.flush();
+
+        bw.close();
+        br.close();
+    }
+}

--- a/양진기/week8[투 포인터]/1644.java
+++ b/양진기/week8[투 포인터]/1644.java
@@ -1,0 +1,50 @@
+import java.io.*;
+import java.util.*;
+
+class Main{
+    static boolean prime[];
+    static ArrayList<Integer> prime_numbers = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+
+        // 소수 구하기
+        prime = new boolean[n+1];
+
+        prime[0] = prime[1] = true; // 0과 1은 소수가 아니다 -> true
+        for(int i=2; i*i <= n; i++){
+            if(!prime[i]){      // 소수 중에서 (false)
+                for(int j=i*i; j<=n; j += i){   // 소수 자기 자신의 배수는 소수가 아니다.
+                    prime[j] = true;    // 소수가 아니다 -> true
+                }
+            }
+        }
+
+        for(int i=1; i<=n; i++){
+            if(!prime[i]){
+                prime_numbers.add(i);
+            }
+        }
+
+        // 연속합으로 주어진 정수 구할 수 있는지 판별
+        int start = 0, end = 0, sum = 0, count = 0;
+        while(true){
+            if(sum >= n) {  // sum 감소해야 됨 -> start 오른쪽 이동
+                sum -= prime_numbers.get(start);
+                start++;
+            } else if(end == prime_numbers.size()){ // end >= 소수 사이즈 시 종료
+                break;
+            } else {    // sum 증가해야 됨 -> end 오른쪽 이동
+                sum += prime_numbers.get(end);
+                end++;
+            }
+
+            if(n == sum) {
+                count++;
+            }
+        }
+        System.out.println(count);
+    }
+}

--- a/양진기/week8[투 포인터]/1806.java
+++ b/양진기/week8[투 포인터]/1806.java
@@ -1,0 +1,69 @@
+import java.io.*;
+import java.util.*;
+
+class Main{
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int s = Integer.parseInt(st.nextToken());
+
+        int[] seq = new int[n+1];
+        st = new StringTokenizer(br.readLine());
+        for(int i=0; i<n; i++){
+            seq[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int start = 0;
+        int end = 0;
+        int sum = 0;
+        int count = 0;
+        int min = Integer.MAX_VALUE;
+
+        while(start <= end && end <= n){
+
+            if(sum >= s){
+
+                sum -= seq[start];
+                start++;
+                count = end - start + 1;
+                min = Math.min(min, count);
+            } else if(sum < s) {
+                sum += seq[end];
+                end++;
+            }
+//            if(sum >= s){
+//                min = Math.min(min, count);
+//                sum -= seq[start];
+//                start++;
+//                count--;
+//            } else if(sum < s) {
+//                sum += seq[end];
+//                end++;
+//                count++;
+//            }
+
+//            if(sum > s){
+//                sum -= seq[start];
+//                start++;
+//                count--;
+//            } else if(sum < s){
+//                sum += seq[end];
+//                end++;
+//                count++;
+//            } else if(sum == s){
+//                min = Math.min(min, count);
+//                sum -= seq[start];
+//                start++;
+//                count = 0;
+//            }
+        }
+
+        if(min == Integer.MAX_VALUE){
+            System.out.println("0");
+        } else {
+            System.out.println(min);
+        }
+    }
+}

--- a/양진기/week8[투 포인터]/2283.java
+++ b/양진기/week8[투 포인터]/2283.java
@@ -1,0 +1,46 @@
+import java.util.*;
+import java.io.*;
+
+class Main{
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+
+        int[] arr = new int[1_000_002];
+
+        for(int i=0; i<n; i++){
+            st = new StringTokenizer(br.readLine());
+            int left = Integer.parseInt(st.nextToken());
+            int right = Integer.parseInt(st.nextToken());
+
+            arr[left]++;
+            arr[right]--;
+        }
+
+        for(int i=1; i<arr.length; i++){
+            arr[i] += arr[i-1];
+        }
+
+        int start = 0;
+        int end = 0;
+        int sum = 0;
+        while(true){
+            if(sum < k) {
+                sum += arr[end];
+                end++;
+            } else if(sum > k){
+                sum -= arr[start];
+                start++;
+            } else {
+                System.out.println(start + " " + end);
+                return;
+            }
+            if(end == 1_000_001) break;
+        }
+        System.out.println("0 0");
+    }
+}

--- a/양진기/week8[투 포인터]/22857.java
+++ b/양진기/week8[투 포인터]/22857.java
@@ -1,0 +1,43 @@
+import java.io.*;
+import java.util.*;
+
+class Main{
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        int arr[] = new int[n];
+
+        st = new StringTokenizer(br.readLine());
+        for(int i=0; i<n; i++){
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int l = 0;  // 왼쪽 포인터
+        int r = 0;  // 오른쪽 포인터
+        int odd = 0;
+        int even = 0;
+
+        if(arr[0] % 2 == 0) even++; // 첫번째 인덱스가 짝수
+        else odd++; // 첫번째 인덱스가 홀수
+
+        int answer = even;
+        // R, L의 사이에 홀수의 갯수가 K개 초과면 L증가, 반대는 R증가
+        while(r >= l){
+            if(odd > k){    // 홀수의 개수가 k보다 초과하면 왼쪽 포인터 증가
+                if(arr[l] % 2 == 0) even--; // 왼쪽 포인터가 짝수
+                else odd--; // 왼쪽 포인터가 홀수
+                l++;    // 왼쪽 포인터 이동
+            } else {    // 홀수의 개수가 k보다 작거나 같으면 오른쪽 포인터 증가
+                r++;    // 오른쪽 포인터 이동
+                if(r >= n) break;   // 오른쪽 포인터가 수열 크기 이상이면 종료
+                if(arr[r] % 2 == 0) even++;
+                else odd++;
+                answer = Math.max(answer, even);
+            }
+        }
+        System.out.println(answer);
+    }
+}

--- a/양진기/week8[투 포인터]/2470.java
+++ b/양진기/week8[투 포인터]/2470.java
@@ -1,0 +1,43 @@
+import java.io.*;
+import java.util.*;
+
+class Main{
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+        int[] arr = new int[n];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for(int i=0; i<n; i++){
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(arr);   // 오름차순 정렬
+
+        int start = 0;
+        int end = n-1;
+
+        int ans1 = 0;
+        int ans2 = 0;
+
+        int gap = Integer.MAX_VALUE;
+        int temp, sum;
+        while(start < end){ // 왼쪽 포인터가 오른쪽 포인터보다 작을 때까지
+            sum = arr[start] + arr[end];    // 합 구하기
+            temp = Math.abs(sum);           // 합의 절대값 구하기
+            if(temp < gap){                 // 방금 구한 절댓값이 이전에 저장한 차이값보다 작은가
+                gap = temp;                 // 최소 차이값 갱신
+                ans1 = arr[start];          // 정답1 갱신
+                ans2 = arr[end];            // 정답2 갱신
+            }
+            if(sum > 0){    // 둘의 차이가 양수면 오른쪽 포인터를 왼쪽으로 움직여 0에 가깝게
+                end--;
+            } else {        // 둘의 차이가 음수면 왼쪽 포인터를 오른쪽으로 움직여 0에 가깝게
+                start++;
+            }
+        }
+        System.out.println(ans1 + " " + ans2);
+
+    }
+}

--- a/양진기/week8[투 포인터]/3273.java
+++ b/양진기/week8[투 포인터]/3273.java
@@ -1,0 +1,39 @@
+import java.util.*;
+import java.io.*;
+
+class Main{
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+        int[] seq = new int[n];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for(int i=0; i<n; i++){
+            seq[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int x = Integer.parseInt(br.readLine());
+
+        int start = 0;
+        int end = n-1;
+        int count = 0;
+
+        Arrays.sort(seq);
+
+        while(start < end) {
+            int sum = seq[start] + seq[end];
+            if(sum == x) {
+                count++;
+            }
+
+            if(sum < x) {
+                start++;
+            }
+            else {
+                end--;
+            }
+        }
+        System.out.println(count);
+    }
+}


### PR DESCRIPTION
- [BOJ 22857 가장 긴 짝수 연속한 부분 수열](https://www.acmicpc.net/problem/22857)
   - 1 이상인 정수 → 자연수
   - 연속하다
   - N이 최대 50,000 → O(N^2)은 불가
   - 자연수, 연속하다, O(N^2) 불가 → 투 포인터 고려
     

- [BOJ 3273 두 수의 합](https://www.acmicpc.net/problem/3273)
   - 양의 정수 → 자연수
   - 서로 다른 → 중복이 없다.
   - 1 ≤ i < j ≤ n → 정렬해야 한다.
   - N이 최대 100,000 → O(N^2)은 불가
   - 자연수, 중복이 없다, O(N^2) 불가 → 투 포인터 고려
        - 중복이 없다, 정렬해야 한다 → 포인터 2개가 양끝에서 반대로 진행하는 방식

- [BOJ 2470 두 용액](https://www.acmicpc.net/problem/2470)
   - N개의 용액들의 특성값은 모두 다르고 → 중복이 없다.
   - [-2, 4, -99, -1, 98] → 정렬하는 게 좋다. (0을 맞춰야 하는데 가운데로 갈 수록 절대값이 작아지기 때문)
   - 중복이 없다, 정렬해야 한다 → 포인터 2개가 양끝에서 반대로 진행하는 방식

- [BOJ 1806 부분합](https://www.acmicpc.net/problem/1806)
   - 10,000 이하의 자연수
   - 연속하다
   - N이 최대 100,000 → O(N^2)은 불가
   - 자연수, 연속하다, O(N^2) 불가 → 투 포인터 고려


- [BOJ 1644 소수의 연속합](https://www.acmicpc.net/problem/1644)
   - 자연수
   - 연속하다
   - N이 최대 4,000,000 → O(N^2)은 불가
   - 자연수, 연속하다, O(N^2) 불가 → 투 포인터 고려

- [BOJ 1644 냅색문제](https://www.acmicpc.net/problem/1450)
   - 물건을 넣거나 넣지 않는다. → 2가지
     - 물건이 최대 30개 → 2^30
   - 2^30은 시간 초과이므로 반으로 나눈다. → meet in the middle 투 포인터
     - 2^15 + 2^15 = O(2^15)
   - sum1 + sum2이 C가 되는 경우를 찾아야 한다.
     - C - sum1 = sum2 이므로, sum2를 이분 탐색으로 찾아 시간을 더 줄여본다.

- [BOJ 2283 구간 자르기](https://www.acmicpc.net/problem/2283)
   - 선분이 겹치는 구간을 누적합으로 구함