### PR TITLE
[10주차] 트리 / java - 양진기

### DIFF
--- a/양진기/week10[트리]/1167.java
+++ b/양진기/week10[트리]/1167.java
@@ -1,0 +1,92 @@
+import java.io.*;
+import java.util.*;
+
+class Main{
+    static int n;
+    static int result = 0;
+    static int max_node = 0;
+    static ArrayList<Edge>[] nodes;
+
+    static class Edge{  // 트리(그래프) 저장용
+        int end;
+        int weight;
+
+        public Edge(int end, int weight) {
+            this.end = end;
+            this.weight = weight;
+        }
+    }
+
+    static class Node{ // BFS 탐색용
+        int idx;
+        int cnt;
+
+        public Node(int idx, int cnt) {
+            this.idx = idx;
+            this.cnt = cnt;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        n = Integer.parseInt(br.readLine());
+
+        nodes = new ArrayList[n+1];
+        for(int i=1; i<=n; i++){
+            nodes[i] = new ArrayList<>();   // 배열이라는 최상단 폴더에 ArrayList<Edge>라는 하위폴더
+        }
+
+        for(int i=1; i<=n; i++){
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int fromNode = Integer.parseInt(st.nextToken());    // 먼저 정점 번호가 주어지고
+            while(true){
+                int toNode = Integer.parseInt(st.nextToken()); // 하나는 정점번호,
+                if(toNode == -1) break; // 마지막에는 -1이 입력으로 주어진다
+
+                int weight = Integer.parseInt(st.nextToken()); // 다른 하나는 그 정점까지의 거리이다
+
+                nodes[fromNode].add(new Edge(toNode, weight));  // 배열이라는 최상단 폴더에 ArrayList<Edge>라는 하위폴더
+            }
+        }
+
+        // 임의의 노드는 1로 지정 (1이 아니어도 됨)
+        // 노드 1에서 가장 멀리 떨어진 노드와의 거리를 result에 저장
+        // 노드 1에서 가장 멀리 떨어진 노드는 max_node로 저장됨
+        bfs(1);
+
+        // max_node에서 가장 멀리 떨어진 노드와의 거리를 result에 저장
+        bfs(max_node);
+
+        System.out.println(result);
+    }
+
+    static void bfs(int start){
+
+        boolean[] visited = new boolean[n + 1]; // 방문 체크 배열
+
+        Queue<Node> queue = new LinkedList<>();
+        queue.add(new Node(start, 0));  // 초기값 추가
+        visited[start] = true;  // 초기값 방문 true
+
+        int max_cnt = 0;
+
+        while(!queue.isEmpty()){
+            Node now = queue.poll();    // 맨 앞의 값 가져오기
+
+            if(now.cnt > max_cnt){
+                max_cnt = now.cnt;  // 가장 멀리 떨어진 노드의 거리
+                max_node = now.idx; // 가장 멀리 떨어진 노드의 번호
+            }
+
+            for(Edge e : nodes[now.idx]){   // nodes[1]에 해당하는 ArrayList<Edge>
+                if(!visited[e.end]){        // toNode에 방문하지 않았다면
+                    visited[e.end] = true;  // 방문했다고 바꾸고
+                    // 다음 노드를 큐에 추가 (현재의 거리에 다음 노드의 가중치를 더함)
+                    queue.add(new Node(e.end, now.cnt + e.weight));
+                }
+            }
+        }
+        result = Math.max(result, max_cnt);
+    }
+}

--- a/양진기/week10[트리]/11725.java
+++ b/양진기/week10[트리]/11725.java
@@ -1,0 +1,51 @@
+import java.util.*;
+import java.io.*;
+
+class Main{
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+
+        ArrayList<ArrayList<Integer>> tree = new ArrayList<>();
+
+        // 노드 개수만큼 트리에 추가
+        for(int i=0; i<=N; i++){    // 트리의 개수는 N개. ArrayList는 0, 1부터 N까지 쓸것
+            tree.add(new ArrayList<>());
+        }
+
+        // 입력값을 받아 트리에 입력
+        StringTokenizer st;
+        for(int i=0; i<N-1; i++){ // 트리의 간선은 N-1개
+            st = new StringTokenizer(br.readLine());
+            int node1 = Integer.valueOf(st.nextToken());
+            int node2 = Integer.valueOf(st.nextToken());
+
+            // 트리는 무방향이기 때문에 양쪽에 정보 추가
+            tree.get(node1).add(node2);
+            tree.get(node2).add(node1);
+        }
+
+        boolean visited[] = new boolean[N+1];   // 방문 체크 배열
+        int[] parentNode = new int[N+1];        // 부모 노드 저장 배열
+
+        // BFS
+        Queue<Integer> queue = new LinkedList<>();
+        queue.add(1);       // 루트 노드가 1이기 때문에 1부터 시작
+        visited[1] = true;  // 루트 노드 방문 체크
+        while(!queue.isEmpty()){    // 큐에 값이 있으면
+            int v = queue.poll();   // 맨 앞의 값 가져옴(부모 노드)
+            for(int node : tree.get(v)){    // v안에 있는 node는 자식 노드임 (트리는 인접한 것이 형제일 수 없다)
+                if(!visited[node]){         // 방문하지 않은 노드라면
+                    visited[node] = true;   // 방문한 것으로 바꾸고
+                    queue.add(node);        // 큐에 노드 추가
+                    parentNode[node] = v;   // 루트부터 아래 방향으로 찾으므로 v는 부모노드, node는 자식 노드
+                }
+            }
+        }
+        for(int i=2; i<=N; i++){    // 부모 노드 번호를 2번 노드부터 순서대로 출력
+            System.out.println(parentNode[i]);
+        }
+    }
+}

--- a/양진기/week10[트리]/1967.java
+++ b/양진기/week10[트리]/1967.java
@@ -1,0 +1,56 @@
+import java.util.*;
+import java.io.*;
+
+class Main{
+    static class Node{
+        int idx, cost;
+
+        public Node(int idx, int cost) {
+            this.idx = idx;
+            this.cost = cost;
+        }
+    }
+
+    static int N;
+    static List<Node> list[];
+    static boolean visited[];
+    static int ans = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+        list = new ArrayList[N+1];
+        for(int i=1; i<=N; i++){
+            list[i] = new ArrayList<Node>();
+        }
+
+        for(int i=0; i<N-1; i++){    // 트리의 간선 수는 정점 - 1개
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int fromNode = Integer.parseInt(st.nextToken());
+            int toNode = Integer.parseInt(st.nextToken());
+            int weight = Integer.parseInt(st.nextToken());
+
+            // 무방향이므로 양방향에 추가
+            list[fromNode].add(new Node(toNode, weight));
+            list[toNode].add(new Node(fromNode, weight));
+        }
+
+        for(int i=1; i<=N; i++){
+            visited = new boolean[N+1];
+            visited[i] = true;
+            dfs(i, 0);
+        }
+        System.out.println(ans);
+    }
+
+    static void dfs(int num, int dim){
+        for(Node node : list[num]){ // 시작노드에 인접한 노드를 가져온다.
+            if(!visited[node.idx]){ // 방문하지 않았다면
+                visited[node.idx] = true;   // 방문한 것으로 바꾸고
+                dfs(node.idx, dim + node.cost); // 거리를 누적한다.
+            }
+        }
+        ans = (ans < dim) ? dim : ans;
+    }
+}

--- a/양진기/week10[트리]/1991.java
+++ b/양진기/week10[트리]/1991.java
@@ -1,0 +1,95 @@
+import java.util.*;
+import java.io.*;
+
+class Main{
+    static class Node{
+        char value; // 값
+        Node left;  // 왼쪽 자식 노드
+        Node right; // 오른쪽 자식 노드
+
+        public Node(char value, Node left, Node right) {
+            this.value = value;
+            this.left = left;
+            this.right = right;
+        }
+    }
+
+    static int N;
+    static Node head = new Node('A', null, null);   // 항상 A가 루트 노드가 된다
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+
+        StringTokenizer st;
+        for(int i=0; i<N; i++){
+            st = new StringTokenizer(br.readLine());
+            char parentNode = st.nextToken().charAt(0);   // 노드
+            char left = st.nextToken().charAt(0);   // 왼쪽 자식 노드
+            char right = st.nextToken().charAt(0);  // 오른쪽 자식 노드
+
+            insertNode(head, parentNode, left, right);    // head (root부터 시작)
+        }
+
+        preOrder(head);     // 전위
+        System.out.println();
+        inOrder(head);      // 중위
+        System.out.println();
+        postOrder(head);    // 후위
+        System.out.println();
+    }
+
+    static void insertNode(Node temp, char parentNode, char left, char right){
+
+        // 현재 노드는 head부터 시작해서 내려간다.
+        if(temp.value == parentNode){ // 현재 노드가 부모 노드여야 자식 노드를 추가한다.
+            temp.left = (left == '.') ? null : new Node(left, null, null);      // .이 아니면 왼쪽 자식 노드 생성
+            temp.right = (right == '.') ? null : new Node(right, null, null);   // .이 아니면 오른쪽 자식 노드 생성
+        }
+        else { // 현재 노드가 부모 노드가 아니면
+            // 재귀
+
+            // 루트의 왼쪽부터 시작.
+            // 현재 노드의 왼쪽 자식노드의 자식 노드가 없다면
+            if(temp.left != null) {
+                insertNode(temp.left, parentNode, left, right); // 현재 노드의 왼쪽 자식노드를 입력한다.
+            }
+
+            // 루트의 오른쪽부터 시작.
+            // 현재 노드의 오른쪽 자식노드의 자식 노드가 없다면
+            if(temp.right != null) {
+                insertNode(temp.right, parentNode, left, right); // 현재 노드의 오른쪽 자식노드를 입력한다.
+            }
+        }
+
+    }
+
+    // 전위
+    static void preOrder(Node node){
+        if(node == null) return;
+        // ROOT -> LEFT -> RIGHT
+        System.out.print(node.value);
+        preOrder(node.left);
+        preOrder(node.right);
+    }
+
+    // 중위
+    static void inOrder(Node node){
+        if(node == null) return;
+        // LEFT -> ROOT -> RIGHT
+        inOrder(node.left);
+        System.out.print(node.value);
+        inOrder(node.right);
+    }
+
+    // 후위
+    static void postOrder(Node node){
+        if(node == null) return;
+        // LEFT -> RIGHT -> ROOT
+        postOrder(node.left);
+        postOrder(node.right);
+        System.out.print(node.value);
+    }
+}

--- a/양진기/week10[트리]/2263.java
+++ b/양진기/week10[트리]/2263.java
@@ -1,0 +1,66 @@
+import java.util.*;
+import java.io.*;
+
+class Main{
+    static int n;
+    static int[] in, post, pre;
+    static int idx;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        n = Integer.parseInt(br.readLine());
+
+        in = new int[n];        // 중위
+        post = new int[n];      // 후위
+        pre = new int[n];       // 전위
+
+        // inOrder (중위)
+        String[] sarr = br.readLine().split(" ");
+        for(int i=0; i<n; i++){
+            in[i] = Integer.parseInt(sarr[i]);
+        }
+
+        // postOrder (후위)
+        sarr = br.readLine().split(" ");
+        for(int i=0; i<n; i++){
+            post[i] = Integer.parseInt(sarr[i]);
+        }
+
+        getPreOrder(0, n-1, 0, n-1);    // 중위, 후위에서 가져온다.
+
+        // 전위 순회 출력
+        for(int n : pre){
+            bw.write(n + " ");
+        }
+        bw.flush();
+    }   // end of main
+
+    // is : 인오더 시작, ie : 인오더 끝
+    // ps : 포스트오더 시작 , pe : 포스트오더 끝
+    static void getPreOrder(int is, int ie, int ps, int pe){
+
+        if(is <= ie && ps <= pe){
+            // 포스트오더의 마지막 노드인 루트가 프리오더의 첫번째 노드인 루트가 된다.
+            pre[idx++] = post[pe];  // 포스트 오더의 가장 오른쪽은 (post[pe]) 루트 노드이다.
+
+            int pos = is;
+            for(int i = is; i <= ie; i++){  // 인오더에서 루트 노드의 위치를 찾음
+
+                if(in[i] == post[pe]){  // 포스트오더의 마지막값인 루트를 가져와 찾는다.
+                    pos = i;    // 인오더에서 루트 위치를 찾는다.
+                    break;
+                }
+            }
+
+            // 왼쪽 자식 트리를 가지고 다시 똑같은 과정을 반복한다.
+            // 인오더 : 왼쪽 ~ 루트 -1, 포스트오더 : 왼쪽 ~ ps + pos - is
+            getPreOrder(is, pos - 1, ps, ps + pos - is - 1);
+
+            // 오른쪽 자식 트리를 가지고 다시 똑같은 과정을 반복한다.
+            // 인오더 : 루트+1 ~ 오른쪽, 포스트오더 : ps + pos - is ~ 오른쪽
+            getPreOrder(pos + 1, ie, ps + pos - is, pe - 1);
+        }
+    }
+}

--- a/양진기/week10[트리]/4803.java
+++ b/양진기/week10[트리]/4803.java
@@ -1,0 +1,93 @@
+import java.util.*;
+import java.io.*;
+
+class Main{
+    static ArrayList<ArrayList<Integer>> graph;
+    static boolean[] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        int testcase = 1;
+
+        while(true){
+            st = new StringTokenizer(br.readLine());
+            int n = Integer.parseInt(st.nextToken());   // 정점
+            int m = Integer.parseInt(st.nextToken());   // 간선
+
+            if(n == 0 && m == 0) break;
+
+            // 그래프 초기화
+            graph = new ArrayList<>();
+            for(int i=0; i<=n; i++){
+                graph.add(new ArrayList<>());
+            }
+
+            // 그래프 구성
+            for(int i=0; i<m; i++){
+                st = new StringTokenizer(br.readLine());
+                int a = Integer.parseInt(st.nextToken());
+                int b = Integer.parseInt(st.nextToken());
+
+                // 양방향 추가
+                graph.get(a).add(b);
+                graph.get(b).add(a);
+            }
+
+            visited = new boolean[n + 1];
+
+            int count = 0;  // 트리 개수
+            // 여러 트리가 존재할 수 있으므로 모든 노드를 검사해봄
+            for(int i=1; i<=n; i++){
+                if(!visited[i]){
+                    count += checkTree(i);
+                }
+            }
+
+            if(count == 0){
+                sb.append("Case " + testcase++ + ": No trees.");
+            } else if (count == 1){
+                sb.append("Case " + testcase++ + ": There is one tree.");
+            } else {
+                sb.append("Case " + testcase++ + ": A forest of " + count + " trees.");
+            }
+            sb.append("\n");
+        } // end of while(true)
+        bw.write(sb.toString());
+        bw.close();
+        br.close();
+    } // end of main
+
+    /**
+     트리의 경우 노드 개수 = 간선 개수 + 1을 활용
+     양방향 간선으로 그래프를 구성하였으므로 간선 개수가 2배
+     node = (edge / 2) + 1이면 트리이다.
+
+     @param start 시작점
+     @return 트리이면 1, 아니면 0
+     */
+    static int checkTree(int start){
+        Queue<Integer> queue = new LinkedList<>();
+        queue.offer(start);
+        int node = 0;
+        int edge = 0;
+
+        while(!queue.isEmpty()){
+            int cur = queue.poll();
+            node += 1;  // 큐에 정점이 담겼으므로 +1
+            visited[cur] = true;
+
+            for(int next : graph.get(cur)){
+                edge += 1;  // 다음 정점이 있다는 것은 간선이 있다는 것 +1
+                if(!visited[next]){
+                    queue.offer(next);
+                }
+            }
+        }
+        return (edge / 2) + 1 == node ? 1 : 0;  // 트리면 1, 아니면 0
+    }
+}

--- a/양진기/week10[트리]/5639.java
+++ b/양진기/week10[트리]/5639.java
@@ -1,0 +1,59 @@
+import java.io.*;
+import java.util.*;
+
+class Main{
+    static class Node{
+        int num;
+        Node left;
+        Node right;
+
+        public Node(int num) {
+            this.num = num;
+        }
+
+        public Node(int num, Node left, Node right) {
+            this.num = num;
+            this.left = left;
+            this.right = right;
+        }
+
+        void insert(int n){
+            if(n < this.num) {  // N보다 작으면 왼쪽 서브트리에
+                if(this.left == null){          // 왼쪽 자식 노드가 없으면
+                    this.left = new Node(n);    // 왼쪽 자식 노드를 생성한다.
+                } else {                        // 왼쪽 자식노드가 있으면
+                    this.left.insert(n);        // 왼쪽 자식노드 아래에 다시 추가한다.
+                }
+            } else {    // N보다 크면 오른쪽 서브 트리에 (같은 키를 가지는 노드는 없다. -> 중복 없다)
+                if(this.right == null){         // 오른쪽 자식 노드가 없으면
+                    this.right = new Node(n);   // 오른쪽 자식 노드를 생성한다.
+                } else {                        // 오른쪽 자식노드가 있으면
+                    this.right.insert(n);       // 오른쪽 자식노드 아래에 다시 추가한다.
+                }
+            }
+        } // end of void
+    } // end of Node
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        Node root = new Node(Integer.parseInt(br.readLine())); // 전위 순회는 루트 노드를 제일 먼저 방문한다.
+        String input;
+        while (true) {
+            input = br.readLine();
+            if(input == null || input.equals("")) break;    // 빈 값이 들어올 때까지 값을 받음
+
+            root.insert(Integer.parseInt(input)); // 루트 노드 아래에 노드를 추가한다.
+        }
+        postOrder(root);
+    } // end of main
+
+    static void postOrder(Node node){
+        if(node == null) return;
+
+        // 후위 순회 (LEFT 서브트리 -> RIGHT 서브트리 -> ROOT)
+        postOrder(node.left);
+        postOrder(node.right);
+        System.out.println(node.num);
+    }
+}


### PR DESCRIPTION
- [BOJ 11725 트리의 부모 찾기](https://www.acmicpc.net/problem/11725)
   - 간선이 연결된 정점은 부모 노드이거나 자식노드이다.
      - 동일한 레벨의 형제 노드는 연결되지 않는다. 
      - 연결된 정점을 찾아서 부모인 경우 따로 배열에 저장해둔다.
   - DFS, BFS 모두 가능 

- [BOJ 1167 트리의 지름](https://www.acmicpc.net/problem/1167)
   - 한 정점에서 다른 정점으로 가는 경로는 유일하다.
      - 임의의 노드 1개에서 가장 먼 노드를 구한다.
      - 앞에서 구한 노드에서 다시 한번 가장 먼 노드를 찾으면 된다.

- [BOJ 1967 트리의 지름](https://www.acmicpc.net/problem/1967)
   - 한 정점에서 다른 정점으로 가는 경로는 유일하다.
      - 임의의 노드 1개에서 가장 먼 노드를 구한다.
      - 앞에서 구한 노드에서 다시 한번 가장 먼 노드를 찾으면 된다.

- [BOJ 1991 트리 순회](https://www.acmicpc.net/problem/1991)
   - 전위 순회 : **(루트)** (왼쪽 자식) (오른쪽 자식)
   - 중위 순회 : (왼쪽 자식) **(루트)** (오른쪽 자식)
   - 후위 순회 : (왼쪽 자식) (오른쪽 자식) **(루트)**

- [BOJ 2263 트리의 순회](https://www.acmicpc.net/problem/11725)
   - 후위 순회에서 가장 오른쪽에 있는 값이 트리의 루트가 된다.
   - 중위 순회에서 트리 노드를 기준으로 왼쪽 자식 트리와 오른쪽 자식 트리를 찾는다.
   - 루트는 전위 순회의 첫 번째 노드가 된다. 

- [BOJ 5639 이진 검색 트리](https://www.acmicpc.net/problem/5639)
   - 노드의 왼쪽 서브트리에 있는 모든 노드의 키는 노드의 키보다 작다.
   - 노드의 오른쪽 서브트리에 있는 모든 노드의 키는 노드의 키보다 크다.
   - 왼쪽, 오른쪽 서브트리도 이진 검색 트리이다.

- [BOJ 4803 트리](https://www.acmicpc.net/problem/4803)
   1. 간선 개수를 활용해 푸는 방법
       - 트리의 경우 (노드 개수 = 간선 개수 + 1)을 활용
       - 양방향 간선으로 그래프를 구성하였으므로 간선 개수가 2배이다.
       - node = (edge / 2) + 1이면 트리이다.
   2. 사이클 여부로 푸는 방법
       - 트리는 사이클이 없다
   3. 유니온 파인드 
