### PR TITLE
[11주차] 유니온 파인드 / java - 양진기

### DIFF
--- a/양진기/week11[유니온 파인드]/10775.java
+++ b/양진기/week11[유니온 파인드]/10775.java
@@ -1,0 +1,54 @@
+import java.io.*;
+import java.util.*;
+
+class Main{
+    static int[] parents;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int G = Integer.parseInt(br.readLine());
+        int P = Integer.parseInt(br.readLine());
+
+        parents = new int[G+1];
+        for(int i=1; i<=G; i++){
+            parents[i] = i; // 부모는 자기 자신으로 초기화
+        }
+        int ans = 0;
+        for(int i=0; i<P; i++){
+            int g = Integer.parseInt(br.readLine());
+            int emptyGate = find(g);    // 최고 부모 노드를 찾는다.
+
+            if(emptyGate != 0){ // 게이트에 도킹이 가능한 경우
+                ans++;
+                // emptyGate와 emptyGate -1 을 합친다.
+                // 최고 부모 노드를 1씩 누적해서 줄인다. (해당 노드는 도킹을 했기 때문에 해당 노드 미만의 것들만 도킹 가능)
+                union(emptyGate, emptyGate - 1);
+            } else {
+                break;
+            }
+        }
+        System.out.println(ans);
+    }
+
+    // 최고 부모 찾기
+    static int find(int x){
+        if(parents[x] == x) return x;
+        else return parents[x] = find(parents[x]);
+    }
+
+    // 합집합 연산
+    static void union(int x, int y){
+        x = find(x);    // 최고 부모 찾기
+        y = find(y);    // 최고 부모 찾기
+
+        if(x != y){
+            if(x < y){  // 작은 쪽으로 합친다.
+                parents[y] = x;
+            } else {
+                parents[x] = y;
+            }
+        }
+    }
+}

--- a/양진기/week11[유니온 파인드]/1717.java
+++ b/양진기/week11[유니온 파인드]/1717.java
@@ -1,0 +1,75 @@
+import java.io.*;
+import java.util.*;
+
+class Main{
+
+    static int[] parent;    // 부모를 저장할 배열
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());   // 원소의 갯수
+        int M = Integer.parseInt(st.nextToken());   // 연산의 갯수
+
+        parent = new int[N+1]; // 원소는 0부터 N까지 N+1개이다.
+        for(int i=1; i<=N; i++){
+            parent[i] = i;      // 자기 자신으로 초기화
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for(int i=0; i<M; i++){
+            st = new StringTokenizer(br.readLine());
+            int command = Integer.parseInt(st.nextToken());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            if(command == 0){
+                union(a, b);    // 유니온 진행
+            } else if (command == 1){
+                sb.append((isSameParent(a, b) ? "YES" : "NO") + "\n");  // 두 원소가 같은 집합(->부모)에 포함되어 있는지를 확인
+            } else {
+                continue;
+            }
+        }
+
+        bw.write(sb.toString());
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    // x의 부모를 찾는 연산
+    public static int find(int x){
+        if(x == parent[x]){ // 부모가 자기 자신이면 x 반환
+            return x;
+        }
+        return parent[x] = find(parent[x]); // 아니면 부모의 부모를 재귀적으로 찾음
+    }
+
+    // y의 부모를 x의 부모로 치환하는 연산 (x > y일 경우 반대)
+    public static void union(int x, int y){
+        x = find(x);    // x의 최종 부모를 찾음
+        y = find(y);    // y의 최종 부모를 찾음
+
+        if(x != y){     // x와 y가 최종 부모가 다르면
+            if(x < y) { // 더 작은 값으로 합친다
+                parent[y] = x;
+            } else {
+                parent[x] = y;
+            }
+        }
+    }
+
+    // x와 y의 부모가 같은지 확인
+    public static boolean isSameParent(int x, int y){
+        x = find(x);    // x의 최종 부모를 찾음
+        y = find(y);    // y의 최종 부모를 찾음
+
+        if(x == y){     // 최종 부모가 같다면 true
+            return true;
+        }
+        return false;
+    }
+}

--- a/양진기/week11[유니온 파인드]/17398.java
+++ b/양진기/week11[유니온 파인드]/17398.java
@@ -1,0 +1,118 @@
+import java.util.*;
+import java.io.*;
+
+class Main{
+    static int[] parents;
+    static long[] groupSize;    // 각 정점의 사이즈
+    static Connection[] connections;    // 통신망 (통신탑들의 집합)
+
+    static class Connection{ // 통신탑 간의 연결 정보
+        int a, b;
+
+        public Connection(int a, int b) {
+            this.a = a;
+            this.b = b;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        int Q = Integer.parseInt(st.nextToken());
+
+        // 부모는 자기 자신으로 초기화
+        parents = new int[N+1];
+        for(int i=1; i<=N; i++){
+            parents[i] = i;
+        }
+
+        // 각 정점의 사이즈는 1로 초기화
+        groupSize = new long[N+1];
+        Arrays.fill(groupSize, 1);
+
+        connections = new Connection[M + 1];
+        for(int i=1; i<=M; i++){
+            st = new StringTokenizer(br.readLine());
+            int X = Integer.parseInt(st.nextToken());
+            int Y = Integer.parseInt(st.nextToken());
+
+            // 통신탑 간의 연결 정보를 담는다.
+            connections[i] = new Connection(X, Y);
+        }
+
+        /**
+         *  제거 예정인 간선을 저장해 두고 나머지 간선을 모두 연결한 상태로
+         *  제거 역순으로 그래프를 Union 작업하여 문제를 해결한다.
+         *  Union-Find 기법은 그래프를 분리하는 상황에서 쓰지 못하기 때문에
+         *  문제를 거꾸로 생각해 해결한다. -> 스택?
+         */
+
+        boolean[] cutLine = new boolean[M + 1];
+        Stack<Integer> stack = new Stack<>();
+        while(Q-- > 0){
+            int idx = Integer.parseInt(br.readLine());
+            cutLine[idx] = true;    // 제거될 지점
+            stack.push(idx);        // 거꾸로
+        }
+
+        for(int i=1; i<=M; i++){
+            if(cutLine[i]) continue;    // 제거될 지점이면 스킵
+            // 제거될 지점이 아니면
+            int a = connections[i].a;
+            int b = connections[i].b;
+
+            union(a, b);    // 제거될 지점이 아닌 통신망을 union한다.
+        }
+
+        long ans = 0L;
+
+        while(!stack.isEmpty()){    // 스택에 원소가 있으면
+            Connection now = connections[stack.pop()];  // 위에서부터 꺼냄
+            int a = find(now.a);    // 최고 부모 찾기
+            int b = find(now.b);    // 최고 부모 찾기
+
+            // 서로 다른 그룹이라면 제거 비용을 구하여 합함
+            // 최고 부모가 같지 않다 -> 다른 그룹이다. -> (그룹 1의 정점 개수) * (그룹 2의 정점 개수)
+            if(a != b) ans += groupSize[a] * groupSize[b];
+
+            // 최고 부모가 같다. -> 같은 그룹이다. -> 비용은 0
+            union(a, b);
+        }
+        System.out.println(ans);
+    }
+
+    // 최고 부모 찾기
+    static int find(int x){
+        if(parents[x] == x) return x;
+        else return parents[x] = find(parents[x]);
+    }
+
+    // 합집합 연산
+    static void union(int x, int y){
+        x = find(x);
+        y = find(y);
+
+//        if(x != y){
+//            if(x < y){
+//                parents[y] = x;
+//            } else {
+//                parents[x] = y;
+//            }
+//        }
+
+        if(x > y){  // 들어오는 값은 x < y가 default라서 반대로 들어올 경우 swap한다.
+            int temp = x;
+            x = y;
+            y = temp;
+        }
+
+        if(x != y){
+            groupSize[x] += groupSize[y];   // 그룹의 개수를 누적한다.
+            parents[y] = x; // 작은 쪽으로 합치는 union 연산
+        }
+    }
+}

--- a/양진기/week11[유니온 파인드]/1976.java
+++ b/양진기/week11[유니온 파인드]/1976.java
@@ -1,0 +1,83 @@
+import java.util.*;
+import java.io.*;
+
+class Main{
+
+    static int[] parent;
+    static int[] plan;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int N = Integer.parseInt(br.readLine());    // 총 정점 갯수
+        int M = Integer.parseInt(br.readLine());    // 여행에 포함된 정점 갯수
+
+        parent = new int[N+1];
+        for(int i=1; i<=N; i++){    // 1부터 N까지
+            parent[i] = i;  // 부모는 자기 자신으로 초기화
+        }
+
+        StringTokenizer st;
+        for(int i=1; i<=N; i++){ // N개의 줄에는 N개의 정수가 주어진다.
+            st = new StringTokenizer(br.readLine());
+
+            for(int j=1; j<=N; j++){
+                int num = Integer.parseInt(st.nextToken());
+
+                // i번째 줄의 j번째 수는 i번 도시와 j번 도시의 연결 정보를 의미한다.
+                if(num == 1){   // 1이면 연결된 것이고 0이면 연결이 되지 않은 것이다.
+                    union(i, j);
+                }
+            }
+        }
+
+        // 마지막 줄에는 여행 계획이 주어진다.
+        st = new StringTokenizer(br.readLine());
+        int start = find(Integer.parseInt(st.nextToken())); // 여행 계획의 첫 지점
+        plan = new int[N+1];
+        for(int i=1; i<M; i++){
+
+            int now = Integer.parseInt(st.nextToken()); // 여행 계획의 첫 지점 이후의 지점들이 순차적으로
+
+            // 각 노드의 "최고" 부모 노드가 전부 같으면, 노드가 전부 연결 돼있다는 의미
+            // 첫 지점과 다음 지점들의 최고 부모 노드가 같은지 비교한다.
+            if(start != find(now)){ // 하나라도 다르면 연결 되어 있지 않다.
+                bw.write("NO\n");
+                bw.flush();
+                bw.close();
+                br.close();
+                return;
+            }
+        }
+
+        bw.write("YES\n");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    // 부모 찾기
+    static int find(int x){
+
+        if(x == parent[x]){
+            return x;
+        }
+        return parent[x] = find(parent[x]);
+    }
+
+    // 합치기
+    static void union(int x, int y){
+
+        int a = find(x);
+        int b = find(y);
+
+        if(a != b){
+            if(a < b){
+                parent[b] = a;
+            } else {
+                parent[a] = b;
+            }
+        }
+    }
+}

--- a/양진기/week11[유니온 파인드]/20040.java
+++ b/양진기/week11[유니온 파인드]/20040.java
@@ -1,0 +1,75 @@
+import java.util.*;
+import java.io.*;
+
+class Main{
+    static int[] parent;    // 부모 노드를 저장
+    static int count = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());   // 점의 개수
+        int m = Integer.parseInt(st.nextToken());   // 차례 수
+
+        parent = new int[n];
+        for(int i=0; i<n; i++){
+            parent[i] = i;  // 부모는 자기 자신으로 초기화
+        }
+
+        boolean check = false;
+        StringBuilder sb = new StringBuilder();
+        while(m-- > 0) {
+            st = new StringTokenizer(br.readLine());
+            count++;
+
+            int p1 = Integer.parseInt(st.nextToken());
+            int p2 = Integer.parseInt(st.nextToken());
+
+            if(isCycle(p1, p2)){    // x와 y의 최고 부모가 같은지 -> 같으면 사이클 완성 가능
+                check = true;       // 사이클 완성한 적 있는지 체크
+                break;
+            } else {                // x와 y의 최고 부모가 같은지 -> 다르면 사이클 완성 불가
+                union(p1, p2);      // 다르면 합집합 연산한다
+            }
+        }
+        if(!check) count = 0;       // 사이클 완성한 적 없다면 0
+
+        bw.write(String.valueOf(count));
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    // 최고 부모 찾기
+    static int find(int x){
+        if(x == parent[x]) return x;
+        else return parent[x] = find(parent[x]);
+    }
+
+    // 합집합 연산
+    static void union(int x, int y){
+        x = find(x);    // 최고 부모 찾기
+        y = find(y);    // 최고 부모 찾기
+
+        if(x != y){
+            if(x < y){
+                parent[y] = x;  // 더 작은 값을 대입
+            } else {
+                parent[x] = y;  // 더 작은 값을 대입
+            }
+        }
+    }
+
+    // x와 y의 최고 부모가 같은지 -> 같으면 사이클 완성 가능
+    static boolean isCycle(int x, int y){
+        x = find(x);
+        y = find(y);
+
+        if(x == y) {    // 같으면 사이클 있다.
+            return true;
+        }
+        return false;   // 같지 않으면 사이클 없다.
+    }
+}

--- a/양진기/week11[유니온 파인드]/23324.java
+++ b/양진기/week11[유니온 파인드]/23324.java
@@ -1,0 +1,90 @@
+import java.io.*;
+import java.util.*;
+
+class Main{
+    static int[] parents;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+
+        parents = new int[N+1];
+        Arrays.fill(parents, -1);   // 부모 배열은 -1로 초기화
+        int a = 0, b = 0;
+        for(int i=1; i<=M; i++){
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+
+            if (i == K){    // 가중치가 1인 K번째 간선은 union 제외 시킨다.
+                a = u;
+                b = v;
+                continue;
+            }
+
+            union(u, v);    // K번째 간선을 제외한 나머지 간선은 union한다.
+        }
+
+        /*
+            가중치가 1인 간선을 기준으로 그룹이 1개 or 2개 생긴다.
+
+            같은 그룹 내에 있는 정점들은 정점 간 이동할 때 가중치가 0이 된다.
+            다른 그룹 간 정점들은 이동할 때 가중치가 1이 된다.
+
+            그룹이 1개라면 모든 정점 쌍의 최단 거리는 0이 된다.
+            그룹이 2개라면 모든 정점 쌍의 최단 거리는 (그룹 1의 정점 개수) * (그룹 2의 정점 개수)
+        */
+
+        a = find(a);    // 제외시킨 간선의 정점의 최고 부모 찾기
+        b = find(b);    // 제외시킨 간선의 정점의 최고 부모 찾기
+
+        // 최고 부모가 같다면 -> 그룹이 1개
+        if(a == b){
+            System.out.println(0);  // 최단 거리는 0
+            return;
+        }
+
+        // 그룹이 2개라면 모든 정점 쌍의 최단 거리는 (그룹 1의 정점 개수) * (그룹 2의 정점 개수)
+        int aCnt = 0 , bCnt = 0;
+        for(int i=1; i<=N; i++){
+            int cur = find(i);
+            if(cur == a){
+                aCnt++;
+            } else if (cur == b){
+                bCnt++;
+            }
+        }
+        System.out.println(1l * aCnt * bCnt);
+
+    }
+
+    // 최고 부모 찾기
+    static int find(int x){
+        if(parents[x] < 0) return x;    // 부모 배열은 -1로 초기화 했었다.
+        else return parents[x] = find(parents[x]);
+    }
+
+    static void union(int x, int y){
+        x = find(x);
+        y = find(y);
+
+//        if(x != y){
+//            if(x < y){
+//                parents[y] = x;
+//            } else {
+//                parents[x] = y;
+//            }
+//        }
+
+        if(x == y) return;
+        int hi = parents[x] < parents[y] ? x : y;   // 작은 값(x)
+        int lo = parents[x] < parents[y] ? y : x;   // 큰 값(y)
+        parents[hi] += parents[lo];
+        parents[lo] = hi;
+    }
+}

--- a/양진기/week11[유니온 파인드]/4195.java
+++ b/양진기/week11[유니온 파인드]/4195.java
@@ -1,0 +1,82 @@
+import java.io.*;
+import java.util.*;
+
+class Main{
+
+    static int[] parent;    // 부모 저장할 배열
+    static int[] count;     // 친구 관계 수
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st;
+
+        int T = Integer.parseInt(br.readLine());
+
+        StringBuilder sb = new StringBuilder();
+        while(T-- > 0){
+            int F = Integer.parseInt(br.readLine());
+
+            parent = new int[F * 2];
+            count = new int[F * 2];
+            for(int i=0; i < F*2; i++){
+                parent[i] = i;  // 자신의 부모는 자기 자신으로 초기화
+//                count[i] = 1;   // 최초 친구 수는 기본값으로 한 명이다.
+            }
+            Arrays.fill(count, 1);
+
+            HashMap<String, Integer> map = new HashMap<>(); // 이름, 인덱스(노드번호)
+            int idx = 0;
+            for(int i=0; i<F; i++){
+                st = new StringTokenizer(br.readLine());
+                String a = st.nextToken();
+                String b = st.nextToken();
+
+                if(!map.containsKey(a)){    // 친구 이름이 없으면 인덱스(노드) 부여
+                    map.put(a, idx++);
+                }
+
+                if(!map.containsKey(b)){    // 친구 이름이 없으면 인덱스(노드) 부여
+                    map.put(b, idx++);
+                }
+
+                sb.append(union(map.get(a), map.get(b)) + "\n");
+            }
+        }
+
+        bw.write(sb.toString());
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    // 최고 부모 찾기
+    static int find(int x){
+        if(parent[x] == x){
+            return x;
+        }
+
+        return parent[x] = find(parent[x]);
+    }
+
+    // 합집합 연산
+    private static int union(int x, int y) {
+        x = find(x);
+        y = find(y);
+
+        if(x != y){
+            if(x < y){                  // 작은 곳에
+                parent[y] = x;          // 합친다.
+                count[x] += count[y];   // 최고 부모 노드에 친구 수를 누적한다.
+                return count[x];
+                // a 먼저 idx++한 후 , b에 idx++해서 map에 추가했으므로 x > y인 경우는 없다...
+            } else {                    // 작은 곳에
+                parent[x] = y;          // 합친다.
+                count[y] += count[x];   // 최고 부모 노드에 친구 수를 누적한다.
+                return count[y];
+            }
+        }
+
+        return count[x];    // 최고 부모 노드에 친구 수가 누적되어 있다.
+    }
+}


### PR DESCRIPTION
- [BOJ 1717 집합의 표현](https://www.acmicpc.net/problem/1717)

   - 대표적인 유니온 파인드 문제 

   - 두 원소의 루트가 같으면, 같은 집합에 포함되어 있다.

- [BOJ 1976 여행 가자](https://www.acmicpc.net/problem/1976)

   - 각 노드의 루트가 전부 같으면, 노드가 전부 연결되어 있다.

- [BOJ 4195 친구 네트워크](https://www.acmicpc.net/problem/4195)

   - 문자열로 처리하기 (map 사용)

   - 루트 노드에 친구 수를 누적한다.

- [BOJ 20040 사이클 게임](https://www.acmicpc.net/problem/20040)

   - C에 속한 임의의 선분의 한 끝점에서 출발하여 모든 선분을 한 번씩만 지나서 출발점으로 되돌아 올 수 있다.

      - 사이클이 있다 → 루트가 같다. 

- [BOJ 23324번 어려운 모든 정점 쌍 최단 거리](https://www.acmicpc.net/problem/23324)

   - 모든 정점의 최단거리를 플로이드 와샬(O(N^3)로 구하면 시간 초과

   - 가중치가 1인 간선을 기준으로 그룹이 1개 or 2개 생긴다.

      - 같은 그룹 내에 있는 정점들은 정점 간 이동할 때 가중치는 0이 된다.

      - 다른 그룹 간 정점들은 이동할 때 가중치가 1이 된다.

      - 그룹이 1개라면 간선을 제거해도 나눠지지 않았으니 모든 정점 쌍의 최단거리는 0이 된다.

      - 그룹이 2개라면 간선을 제거하고 나눠졌으니 모든 정점 쌍의 최단거리는 (그룹1의 정점 개수) * (그룹2의 정점 개수)

- [BOJ 10775 공항](https://www.acmicpc.net/problem/10775)

   - g번 비행기는 g번 이하 게이트에만 도킹이 가능하다.

- [BOJ 17398 통신망 분할](https://www.acmicpc.net/problem/17398)

   - 유니온 파인드는 병합만 가능하고, 분리는 불가능하다.

   - 마지막 분리했던 시점부터 거꾸로 간선 하나씩 union 연산하면서 통신망 크기를 구한다.

      - 스택 사용 